### PR TITLE
Notebook fix

### DIFF
--- a/curvesim/network/utils.py
+++ b/curvesim/network/utils.py
@@ -1,4 +1,6 @@
 import asyncio
+import concurrent
+import functools
 
 from gmpy2 import mpz
 
@@ -39,9 +41,24 @@ def sync(func):
         Sync version of the async function.
     """
 
+    @functools.wraps(func)
     def inner(*args, event_loop=None, **kwargs):
         loop = event_loop or asyncio.get_event_loop()
-        res = loop.run_until_complete(func(*args, **kwargs))
+        coro = func(*args, **kwargs)
+        if loop.is_running():
+            try:
+                future = asyncio.run_coroutine_threadsafe(coro, loop)
+                res = future.result(timeout=60)
+            except concurrent.futures.TimeoutError as e:
+                print("The coroutine took too long, cancelling the task...")
+                future.cancel()
+                raise e
+            except Exception as e:
+                print("The coroutine raised an exception: {!r}".format(e))
+                raise e
+        else:
+            res = loop.run_until_complete(coro)
+
         return res
 
     return inner


### PR DESCRIPTION
Fixes issue #48.

Using `run_until_complete` in jupyter notebook will throw a loop is running error.  So the fix is to check if loop is running and then do alternative logic.

The workaround for now is to create another event loop.  `asyncio` doesn't let this run in the same thread, so another thread is created and the new loop is set to `run_forever` in it.  

Then whenever we need to run a coroutine synchronously, we just submit it to the second running loop.