### PR TITLE
Bugfix: use rates to calc metapool withdrawals

### DIFF
--- a/curvesim/pool/stableswap/interfaces.py
+++ b/curvesim/pool/stableswap/interfaces.py
@@ -347,7 +347,7 @@ def _test_trade_meta(state, pricing_fn, i, j, dx):
     xp = pool_functions.get_xp(state.x, state.rates)
     exchange_args = (
         state.x,
-        state.p,
+        state.rates,
         state.A,
         state.fee,
         state.admin_fee,

--- a/curvesim/pool/stableswap/metapool.py
+++ b/curvesim/pool/stableswap/metapool.py
@@ -469,12 +469,13 @@ class CurveMetaPool(Pool):
         This is a "view" function; it doesn't change the state of the pool.
         """
         A = self.A
-        xp = self._xp()
+        rates = self.rates()
+        xp = self._xp_mem(rates, self.x)
         D0 = self.D()
         D1 = D0 - token_amount * D0 // self.tokens
 
         new_y = self.get_y_D(A, i, xp, D1)
-        dy_before_fee = (xp[i] - new_y) * 10**18 // self.p[i]
+        dy_before_fee = (xp[i] - new_y) * 10**18 // rates[i]
 
         xp_reduced = xp
         if self.fee and use_fee:
@@ -490,7 +491,7 @@ class CurveMetaPool(Pool):
                 xp_reduced[j] -= _fee * dx_expected // 10**10
 
         dy = xp[i] - self.get_y_D(A, i, xp_reduced, D1)
-        dy = (dy - 1) * 10**18 // self.p[i]
+        dy = (dy - 1) * 10**18 // rates[i]
         if use_fee:
             dy_fee = dy_before_fee - dy
             return dy, dy_fee

--- a/curvesim/pool/stableswap/metapool.py
+++ b/curvesim/pool/stableswap/metapool.py
@@ -336,8 +336,9 @@ class CurveMetaPool(Pool):
         >>> pool.exchange(0, 1, 150 * 10**6)
         (149939820, 59999)
         """
-        xp = self._xp()
-        x = xp[i] + dx * self.p[i] // 10**18
+        rates = self.rates()
+        xp = self._xp_mem(rates, self.x)
+        x = xp[i] + dx * rates[i] // 10**18
         y = self.get_y(i, j, x, xp)
         dy = xp[j] - y - 1
 
@@ -349,7 +350,7 @@ class CurveMetaPool(Pool):
         admin_fee = fee * self.admin_fee // 10**10
 
         # Convert all to real units
-        rate = self.p[j]
+        rate = rates[j]
         dy = (dy - fee) * 10**18 // rate
         fee = fee * 10**18 // rate
         admin_fee = admin_fee * 10**18 // rate

--- a/test/fixtures/curve/metapool.vy
+++ b/test/fixtures/curve/metapool.vy
@@ -166,6 +166,17 @@ def rates(i: uint256) -> uint256:
     else:
         raise
 
+# sim: function added for pool sim testing
+@view
+@external
+def p(i: uint256) -> uint256:
+    if i == 0:
+        return self.rate_multiplier
+    elif i == 1:
+        return 1000000000000000000
+    else:
+        raise
+
 
 # sim: function added for pool sim testing
 @view

--- a/test/unit/test_metapool.py
+++ b/test/unit/test_metapool.py
@@ -23,7 +23,7 @@ def initialize_metapool(vyper_metapool, vyper_3pool):
     A = vyper_metapool.A()
     n_coins = vyper_metapool.N_COINS()
     balances = [vyper_metapool.balances(i) for i in range(n_coins)]
-    p = [vyper_metapool.rates(i) for i in range(n_coins)]
+    p = [vyper_metapool.p(i) for i in range(n_coins)]
     lp_total_supply = vyper_metapool.totalSupply()
     fee = vyper_metapool.fee()
     admin_fee = vyper_metapool.admin_fee()


### PR DESCRIPTION
For metapools, calc_withdraw_one_coin used "p" instead of "rates" for some precision conversions. So, when withdrawing the basepool token, the returned amount was not divided by virtual price. 