### PR TITLE
Remove freq from annualized returns computations

### DIFF
--- a/curvesim/iterators/price_samplers/price_volume.py
+++ b/curvesim/iterators/price_samplers/price_volume.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from pandas import Series
 
@@ -34,13 +34,6 @@ class PriceVolume:
 
         self.prices = prices
         self.volumes = volumes
-
-        self.freq = getattr(prices.index, "freq", None)
-        if self.freq:
-            self.freq /= timedelta(minutes=1)  # force minute units
-        else:
-            print("Warning: assuming 30 minute sampling for annualizing returns")
-            self.freq = 30
 
     def __iter__(self):
         """

--- a/curvesim/metrics/base.py
+++ b/curvesim/metrics/base.py
@@ -55,7 +55,8 @@ class MetricBase(ABC):
                 :func:`summary_functions`. If :func:`summary_functions` is not
                 specified, returns None.
         """
-        data = self.metric_function(**state_log)
+        timestamps = state_log["price_sample"].timestamp
+        data = self.metric_function(**state_log).set_index(timestamps)
         return data, summarize_data(data, self.summary_functions)
 
     @property

--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -205,8 +205,6 @@ class PoolValue(PoolPricingMetric):
     numeraire, `self.numeraire`. Each are summarized as annualized returns.
     """
 
-    __slots__ = ["_freq"]
-
     @property
     def pool_config(self):
         ss_plot = {
@@ -266,10 +264,6 @@ class PoolValue(PoolPricingMetric):
                 "plot": ss_plot,
             },
         }
-
-    def __init__(self, pool, freq, **kwargs):
-        self._freq = freq
-        super().__init__(pool)
 
     def get_stableswap_pool_value(self, pool_state, price_sample, **kwargs):
         """

--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -330,10 +330,10 @@ class PoolValue(PoolPricingMetric):
 
     def compute_annualized_returns(self, data):
         """Computes annualized returns from a series of pool values."""
-        intervals = timedelta64(1, "Y") / data.index.to_series().diff()
+        year_multipliers = timedelta64(1, "Y") / data.index.to_series().diff()
         log_returns = log(data).diff()  # pylint: disable=no-member
 
-        return exp((log_returns * intervals).mean()) - 1
+        return exp((log_returns * year_multipliers).mean()) - 1
 
 
 class PriceDepth(PoolMetric):

--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -14,7 +14,7 @@ __all__ = [
 from functools import partial
 
 from altair import Axis, Scale
-from numpy import array, exp, log
+from numpy import array, exp, log, timedelta64
 from pandas import DataFrame, concat
 
 from curvesim.pool.sim_interface import SimCurveMetaPool, SimCurvePool, SimCurveRaiPool
@@ -336,9 +336,10 @@ class PoolValue(PoolPricingMetric):
 
     def compute_annualized_returns(self, data):
         """Computes annualized returns from a series of pool values."""
+        intervals = timedelta64(1, "Y") / data.index.to_series().diff()
         log_returns = log(data).diff()  # pylint: disable=no-member
-        year_mult = 60 / self._freq * 24 * 365
-        return exp(log_returns.mean() * year_mult) - 1
+
+        return exp((log_returns * intervals).mean()) - 1
 
 
 class PriceDepth(PoolMetric):

--- a/curvesim/pipelines/vol_limited_arb/__init__.py
+++ b/curvesim/pipelines/vol_limited_arb/__init__.py
@@ -132,7 +132,7 @@ def pipeline(
             mode=vol_mode,
         )
 
-    metrics = init_metrics(metrics, pool=pool, freq=price_sampler.freq)
+    metrics = init_metrics(metrics, pool=pool)
     strategy = VolumeLimitedStrategy(metrics, vol_mult)
 
     output = run_pipeline(param_sampler, price_sampler, strategy, ncpu=ncpu)


### PR DESCRIPTION
WIP, testing

- removes the "freq" attribute from PriceVolume price_sampler (and downstream references)
- instead uses inter-timestamp-intervals to compute annualized returns
- allows for annualized returns to be computed with non-constant timestamp intervals