### PR TITLE
Use full res int for admin fee metadata

### DIFF
--- a/curvesim/network/subgraph.py
+++ b/curvesim/network/subgraph.py
@@ -361,7 +361,7 @@ async def pool_snapshot(address, chain):
                 "A": int(r["A"]),
                 "fee": int(float(r["fee"]) * 10**10),
                 "fee_mul": fee_mul,
-                "admin_fee": int(r["adminFee"]),
+                "admin_fee": int(float(r["adminFee"]) * 10**10),
             },
             "coins": coins,
             "reserves": {
@@ -395,7 +395,7 @@ async def pool_snapshot(address, chain):
                 "price_oracle": int(r["priceOracle"]),
                 "last_prices": int(r["lastPrices"]),
                 "last_prices_timestamp": int(r["lastPricesTimestamp"]),
-                "admin_fee": int(r["adminFee"]),
+                "admin_fee": int(float(r["adminFee"]) * 10**10),
                 "xcp_profit": int(r["xcpProfit"]),
                 "xcp_profit_a": int(r["xcpProfitA"]),
             },


### PR DESCRIPTION
The subgraph was changed to return a float (e.g., 0.5). This patch converts those floats to contract precision ints (e.g., 5000000000) in the pool metadata.