### PR TITLE
Stub implementation of the SimCurveCryptoPool

### DIFF
--- a/curvesim/pool/cryptoswap/calcs/factory_2_coin.py
+++ b/curvesim/pool/cryptoswap/calcs/factory_2_coin.py
@@ -82,8 +82,6 @@ def newton_y(  # noqa: complexity: 11
     n_coins: int = len(x)
 
     # Safety checks
-    MIN_A = n_coins**n_coins * A_MULTIPLIER // 10
-    MAX_A = n_coins**n_coins * A_MULTIPLIER * 100000
     if not MIN_A <= ANN <= MAX_A:
         raise CurvesimValueError("Unsafe value for A")
     if not MIN_GAMMA <= gamma <= MAX_GAMMA:
@@ -103,17 +101,11 @@ def newton_y(  # noqa: complexity: 11
     x_sorted = sorted(x_sorted, reverse=True)  # From high to low
 
     convergence_limit: int = max(max(x_sorted[0] // 10**14, D // 10**14), 100)
-    if n_coins == 2:
-        S_i: int = x[1 - i]
-        y: int = D**2 // (S_i * n_coins**2)
-        K0_i: int = (10**18 * n_coins) * S_i // D
-    else:
-        for j in range(2, n_coins + 1):
-            _x: int = x_sorted[n_coins - j]
-            y = y * D // (_x * n_coins)  # Small _x first
-            S_i += _x
-        for j in range(n_coins - 1):
-            K0_i = K0_i * x_sorted[j] * n_coins // D  # Large _x first
+
+    # Formula for 2 coins
+    S_i: int = x[1 - i]
+    y: int = D**2 // (S_i * n_coins**2)
+    K0_i: int = (10**18 * n_coins) * S_i // D
 
     y = mpz(y)
     K0_i = mpz(K0_i)
@@ -197,12 +189,8 @@ def newton_D(  # noqa: complexity: 13
     for _ in range(255):
         D_prev: int = D
 
-        if n_coins == 2:
-            K0: int = (10**18 * n_coins**2) * x[0] // D * x[1] // D
-        else:
-            K0: int = 10**18
-            for _x in x:
-                K0 = K0 * _x * n_coins // D
+        # formula for 2 coins
+        K0: int = (10**18 * n_coins**2) * x[0] // D * x[1] // D
 
         _g1k0: int = abs(gamma + 10**18 - K0) + 1
 

--- a/curvesim/pool/cryptoswap/calcs/tricrypto_ng.py
+++ b/curvesim/pool/cryptoswap/calcs/tricrypto_ng.py
@@ -239,17 +239,13 @@ def _newton_y(  # noqa: complexity: 11
     x_sorted = sorted(x_sorted, reverse=True)  # From high to low
 
     convergence_limit: int = max(max(x_sorted[0] // 10**14, D // 10**14), 100)
-    if n_coins == 2:
-        S_i: int = x[1 - i]
-        y: int = D**2 // (S_i * n_coins**2)
-        K0_i: int = (10**18 * n_coins) * S_i // D
-    else:
-        for j in range(2, n_coins + 1):
-            _x: int = x_sorted[n_coins - j]
-            y = y * D // (_x * n_coins)  # Small _x first
-            S_i += _x
-        for j in range(n_coins - 1):
-            K0_i = K0_i * x_sorted[j] * n_coins // D  # Large _x first
+
+    for j in range(2, n_coins + 1):
+        _x: int = x_sorted[n_coins - j]
+        y = y * D // (_x * n_coins)  # Small _x first
+        S_i += _x
+    for j in range(n_coins - 1):
+        K0_i = K0_i * x_sorted[j] * n_coins // D  # Large _x first
 
     y = mpz(y)
     K0_i = mpz(K0_i)

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -916,8 +916,9 @@ class CurveCryptoPool(Pool):
         Returns an LP token price approximating behavior as a constant-product AMM.
         """
         if self.n == 2:
-            price_oracle = self.internal_price_oracle()[0]
-            return 2 * self.virtual_price * _sqrt_int(price_oracle) // 10**18
+            virtual_price = self.virtual_price
+            price_oracle = self.internal_price_oracle()
+            return factory_2_coin.lp_price(virtual_price, price_oracle)
         # TODO: find/implement integer cube root function
         # elif self.n == 3:
         #     price_oracle = self.internal_price_oracle()

--- a/curvesim/pool/sim_interface/__init__.py
+++ b/curvesim/pool/sim_interface/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ["SimCurvePool", "SimCurveRaiPool", "SimCurveMetaPool"]
+__all__ = ["SimCurvePool", "SimCurveRaiPool", "SimCurveMetaPool", "SimCurveCryptoPool"]
 
+from .cryptoswap import SimCurveCryptoPool
 from .metapool import SimCurveMetaPool
 from .pool import SimCurvePool
 from .raipool import SimCurveRaiPool

--- a/curvesim/pool/sim_interface/cryptoswap.py
+++ b/curvesim/pool/sim_interface/cryptoswap.py
@@ -33,8 +33,8 @@ class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
 
     @override
     def price(self, coin_in, coin_out, use_fee=True):
-        # TODO: fill this method in
-        raise SimPoolError("Price not implemented for SimCurveCryptoPool.")
+        # need to implement a dydxfee equivalent on the cryptopool
+        raise SimPoolError("`price` not implemented for SimCurveCryptoPool.")
 
     @override
     def trade(self, coin_in, coin_out, amount_in):
@@ -46,15 +46,26 @@ class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
         return amount_out, fee
 
     def get_in_amount(self, coin_in, coin_out, out_balance_perc):
+        """
+        Get the approximate in-amount to achieve the given percentage
+        of the out-token balance.
+        """
+        raise SimPoolError("`get_in_amount` not implemented for SimCurveCryptoPool.")
         i, j = self.get_asset_indices(coin_in, coin_out)
 
-        A = self.A
-        gamma = self.gamma
-        xp = self._xp()
-        D = self._newton_D(A, gamma, xp)
+        # The cryptoswap (dynamic) fee is calculated on the state `xp`,
+        # which has been adjusted by increasing in-token balance and
+        # decreasing out-token balance.
+        #
+        # This means we can't just back out the `in_amount` using `get_y`
+        # as with stableswap (fixed fee).
+        #
+        # We can use the following get_dx helper function:
+        # https://github.com/curvefi/tricrypto-ng/blob/main/contracts/main/CurveCryptoViews3Optimized.vy#L183
+        # Tricrypto-ng uses this 5 times in a loop, we may want to increase the
+        # number of iterations.
+        in_amount = None
 
-        xp[j] = int(xp[j] * out_balance_perc)
-        in_amount = self._newton_y(A, gamma, xp, D, j)
         return in_amount
 
     @property

--- a/curvesim/pool/sim_interface/cryptoswap.py
+++ b/curvesim/pool/sim_interface/cryptoswap.py
@@ -1,0 +1,64 @@
+from curvesim.exceptions import SimPoolError
+from curvesim.templates import SimAssets
+from curvesim.templates.sim_pool import SimPool
+from curvesim.utils import cache, override
+
+from ..cryptoswap import CurveCryptoPool
+from .asset_indices import AssetIndicesMixin
+
+
+class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        precisions = self.precisions  # pylint: disable=no-member
+        for p in precisions:
+            if p != 1:
+                raise SimPoolError(
+                    "SimPool must have 18 decimals (precision 1) for each coin."
+                )
+
+    @property
+    @override
+    @cache
+    def asset_names(self):
+        """Return list of asset names."""
+        return self.coin_names
+
+    @property
+    @override
+    def _asset_balances(self):
+        """Return list of asset balances in same order as asset_names."""
+        return self.balances
+
+    @override
+    def price(self, coin_in, coin_out, use_fee=True):
+        # TODO: fill this method in
+        raise SimPoolError("Price not implemented for SimCurveCryptoPool.")
+
+    @override
+    def trade(self, coin_in, coin_out, amount_in):
+        """
+        Note all quantities are in D units.
+        """
+        i, j = self.get_asset_indices(coin_in, coin_out)
+        amount_out, fee = self.exchange(i, j, amount_in)
+        return amount_out, fee
+
+    def get_in_amount(self, coin_in, coin_out, out_balance_perc):
+        i, j = self.get_asset_indices(coin_in, coin_out)
+
+        A = self.A
+        gamma = self.gamma
+        xp = self._xp()
+        D = self._newton_D(A, gamma, xp)
+
+        xp[j] = int(xp[j] * out_balance_perc)
+        in_amount = self._newton_y(A, gamma, xp, D, j)
+        return in_amount
+
+    @property
+    @override
+    @cache
+    def assets(self):
+        return SimAssets(self.coin_names, self.coin_addresses, self.chain)

--- a/curvesim/templates/sim_pool.py
+++ b/curvesim/templates/sim_pool.py
@@ -47,7 +47,7 @@ class SimPool(ABC):
         coin_out : str, int
             ID of quote currency; in a swapping context, this is the
             "out"-token.
-        use_fee: bool, default=False
+        use_fee: bool, default=True
             Deduct fees.
 
         Returns
@@ -81,8 +81,8 @@ class SimPool(ABC):
 
         Returns
         -------
-        (int, int, int)
-            (amount of coin `j` received, trading fee, volume)
+        (int, int)
+            (amount of coin `j` received, trading fee)
         """
         raise NotImplementedError
 


### PR DESCRIPTION
### Description

Mostly just added comments to the stub class for `SimCurveCryptoPool` created in #164.  It will be handy to branch off this for multiple pieces of work, including:

- #165 
- #178 
- #179 


### Hygiene checklist

- [ ] <s>Changelog entry</s> (no need, as this is start for other work which will have entries)
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.wsj.net/im-140535/?width=300&size=0.9899458623356535)
