### PR TITLE
Single run plot fix

### DIFF
--- a/changelog.d/20230728_111925_nagakingg_single_run_plot_fix.rst
+++ b/changelog.d/20230728_111925_nagakingg_single_run_plot_fix.rst
@@ -1,0 +1,4 @@
+Added
+-----
+- Support simulations without variable parameters. This allows sims
+  with only a single run (and associated plots).

--- a/curvesim/iterators/param_samplers/parameterized_pool_iterator.py
+++ b/curvesim/iterators/param_samplers/parameterized_pool_iterator.py
@@ -15,7 +15,7 @@ class ParameterizedPoolIterator(ParameterSampler):
     """
 
     # pylint: disable-next=unused-argument
-    def __new__(cls, pool, variable_params, fixed_params=None, pool_map=None):
+    def __new__(cls, pool, variable_params=None, fixed_params=None, pool_map=None):
         """
         Returns a pool-specific ParameterizedPoolIterator subclass.
 
@@ -48,14 +48,14 @@ class ParameterizedPoolIterator(ParameterSampler):
         return super().__new__(subclass)
 
     # pylint: disable-next=unused-argument
-    def __init__(self, pool, variable_params, fixed_params=None, pool_map=None):
+    def __init__(self, pool, variable_params=None, fixed_params=None, pool_map=None):
         """
         Parameters
         ----------
         pool : :class:`~curvesim.templates.SimPool`
             The "template" pool that will have its parameters modified.
 
-        variable_params: dict
+        variable_params: dict, optional
             Pool parameters to vary across simulations.
 
             Keys are parameter names and values are iterables of values. For metapools,

--- a/curvesim/plot/altair/results/make_page.py
+++ b/curvesim/plot/altair/results/make_page.py
@@ -96,14 +96,16 @@ def make_page(data_dict, config, factors, metric_axis, selectors):
         The created chart page.
     """
     kwargs = selectors["kwargs"]
-    charts = concat(data=data_dict["main"], columns=2)
+    page = concat(data=data_dict["main"], columns=2)
 
     for metric_key, cfg in config.items():
         metrics, kwargs["data"] = get_metric_data(metric_key, data_dict)
         subplot = make_subplot(cfg, metrics, factors, metric_axis, kwargs)
-        charts |= subplot
+        page |= subplot
 
-    page = vconcat(selectors["charts"], charts)
+    if factors:
+        page = vconcat(selectors["charts"], page)
+
     return page.resolve_scale(color="independent")
 
 

--- a/curvesim/plot/altair/results/preprocessing.py
+++ b/curvesim/plot/altair/results/preprocessing.py
@@ -119,6 +119,9 @@ def to_histograms(data, factors):
     pandas.DataFrame
         The data converted to histograms.
     """
+    if not factors:
+        return make_histogram(data).reset_index()
+
     return data.groupby(factors).apply(make_histogram).reset_index()
 
 

--- a/curvesim/plot/altair/results/tooltip.py
+++ b/curvesim/plot/altair/results/tooltip.py
@@ -4,8 +4,10 @@ from altair import Tooltip
 def make_tooltip(encoding, metric_axis, factors, prefix=None):
     """Makes a tooltip for a subplot."""
     tooltip = []
-    if "timestamp" in encoding["x"]["shorthand"]:
-        tooltip.append(Tooltip(encoding["x"]["shorthand"], title="Time"))
+
+    x_shorthand = encoding["x"]["shorthand"]
+    if isinstance(x_shorthand, str) and "timestamp" in x_shorthand:
+        tooltip.append(Tooltip(x_shorthand, title="Time"))
 
     title = encoding[metric_axis]["title"]
     if prefix:

--- a/test/unit/test_param_samplers.py
+++ b/test/unit/test_param_samplers.py
@@ -139,10 +139,9 @@ def test_ParameterizedPoolIterator_unmapped_pool_exception():
                 setattr(self, attr, None)
 
     pool = DummyPool()
-    variable_params = {"a": [1, 2], "b": [3, 4]}
 
     with pytest.raises(ParameterSamplerError):
-        ParameterizedPoolIterator(pool, variable_params)
+        ParameterizedPoolIterator(pool)
 
 
 def test_ParameterizedPoolIterator_wrong_pool_exception():
@@ -155,13 +154,12 @@ def test_ParameterizedPoolIterator_wrong_pool_exception():
         pass
 
     pool = DummyPool()
-    variable_params = {"a": 1, "b": 2}
 
     for subclass in DEFAULT_POOL_MAP.values():
         mapping = {DummyPool: subclass}
 
         with pytest.raises(ParameterSamplerError):
-            ParameterizedPoolIterator(pool, variable_params, pool_map=mapping)
+            ParameterizedPoolIterator(pool, pool_map=mapping)
 
 
 @given(*make_parameter_strats(POOL_PARAMS))


### PR DESCRIPTION
### Description

Adds support for single-run simulations (i.e., with no variable parameters).

Closes #169 

- Makes variable_params an optional argument in ParameterizedPoolIterator
- Fixes plotting for single-run simulations (tooltip and histograms)
- Removes plotting selectors from single-run plots
- Removes variable_params arguments from test_param_samplers tests where
  no longer necessary


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)

