### PR TITLE
Compartmentalize `AssetIndicesMixin` Tests

### DIFF
--- a/test/unit/test_coin_indices_mixin.py
+++ b/test/unit/test_coin_indices_mixin.py
@@ -1,5 +1,6 @@
 """Unit tests for SimStableswapBase"""
 import pytest
+import itertools
 
 from curvesim.pool.sim_interface.asset_indices import AssetIndicesMixin
 from curvesim.utils import override
@@ -32,12 +33,36 @@ def sim_pool():
 
 def test_asset_indices(sim_pool):
     """Test index conversion and getting"""
+    # Example calling by symbol
     result = sim_pool.get_asset_indices("SYM_2", "SYM_0")
     assert result == [2, 0]
 
+    names = sim_pool.asset_names
+    name_sets = [
+        list(itertools.permutations(names, r=i)) for i in range(1, len(names) + 1)
+    ]
+    for lst in name_sets:
+        for name_set in lst:
+            name_set = list(name_set)
+            result = sim_pool.get_asset_indices(*name_set)
+            assert result == [names.index(symbol) for symbol in name_set]
+
+    # Example calling by index
     result = sim_pool.get_asset_indices(1, 2)
     assert result == [1, 2]
 
+    indices = sim_pool.asset_indices.values()
+    index_sets = [
+        list(itertools.permutations(indices, r=i)) for i in range(1, len(indices) + 1)
+    ]
+    for lst in index_sets:
+        for index_set in lst:
+            index_set = list(index_set)
+            result = sim_pool.get_asset_indices(*index_set)
+            assert result == index_set
+
     assert sim_pool.asset_indices == {"SYM_0": 0, "SYM_1": 1, "SYM_2": 2}
 
+
+def test_asset_balances(sim_pool):
     assert sim_pool.asset_balances == {"SYM_0": 100, "SYM_1": 200, "SYM_2": 300}


### PR DESCRIPTION
### Description
#172 

- Tested `simpool.get_asset_indices` on every permutation of every subset of `simpool.asset_names` and `simpool.asset_indices.values` inside `test_asset_indices` function
- Moved `simpool.asset_balances` assert to its own function `test_asset_balances`


### Hygiene checklist

- [ ] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [ ] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://twpark.com/wp-content/uploads/2022/10/Tanganyika_Alpaca_2021_CS2-683x1024.jpg)
