### PR TITLE
V2 metrics

### DIFF
--- a/changelog.d/20230810_021523_nagakingg_v2-metrics.rst
+++ b/changelog.d/20230810_021523_nagakingg_v2-metrics.rst
@@ -1,0 +1,13 @@
+Added
+-----
+- Add get_pool_parameters and get_pool_state functions for SimCurveCryptoPool
+- incorporate SimCurveCryptoPool into PoolVolume, PoolBalance, PoolValue metrics
+- Activate ParameterizedCurveCryptoPoolIterator tests
+- test initialization, attributes, properties, methods of each metric type
+
+Changed
+-------
+- Slight reorganization of metric configs/methods to minimize duplication
+- Update metrics.PricingMixin to support price dicts
+- add unmapped pool exception to get_pool_state/get_pool_parameters
+- cache PoolMetric.pool_config for better testing

--- a/curvesim/exceptions/__init__.py
+++ b/curvesim/exceptions/__init__.py
@@ -65,3 +65,11 @@ class SimPoolError(CurvesimException):
 
 class ParameterSamplerError(CurvesimException):
     """Error using a parameter sampler."""
+
+
+class StateLogError(CurvesimException):
+    """Error using a state log (metrics.StateLog)."""
+
+
+class UnregisteredPoolError(StateLogError):
+    """Error raised when a pool type is not recognized by the metrics framework."""

--- a/curvesim/metrics/__init__.py
+++ b/curvesim/metrics/__init__.py
@@ -21,9 +21,9 @@ Metrics recorded during simulations. The submodule includes:
 
 __all__ = ["SimResults", "StateLog", "init_metrics", "make_results", "metrics"]
 
-from .state_log import StateLog
-from .results import SimResults, make_results
 from . import metrics
+from .results import SimResults, make_results
+from .state_log import StateLog
 
 
 def init_metrics(metric_classes, **kwargs):

--- a/curvesim/metrics/base.py
+++ b/curvesim/metrics/base.py
@@ -356,11 +356,11 @@ def get_coin_pairs(prices):
     Returns the coin pairs available in the price data.
     """
     if isinstance(prices, DataFrame):
-        return prices.columns
+        return tuple(prices.columns)
     if isinstance(prices, Series):
-        return prices.index
+        return tuple(prices.index)
     if isinstance(prices, dict):
-        return prices.keys()
+        return tuple(prices.keys())
 
     raise MetricError(
         f"Argument 'price' must be DataFrame, Series, or dict, not {type(prices)}"

--- a/curvesim/metrics/base.py
+++ b/curvesim/metrics/base.py
@@ -327,7 +327,7 @@ class PricingMixin:
             Symbol for the "in" coin; the "base" currency
         quote : str
             Symbol for the "out" coin; the "quote" currency
-        prices : pandas.DataFrame or pandas.Series
+        prices : pandas.DataFrame, pandas.Series, or dict
             Market prices for each pair. In the simulator context, this is provided on
             each iteration of the :mod:`price_sampler`.
 
@@ -337,12 +337,7 @@ class PricingMixin:
             The price of the "base" coin, quoted in the "quote" coin.
 
         """
-        try:
-            coin_pairs = getattr(prices, pandas_coin_pair_attr[type(prices)])
-        except KeyError as e:
-            raise MetricError(
-                f"Argument 'price' must be DataFrame or Series, not {type(prices)}"
-            ) from e
+        coin_pairs = get_coin_pairs(prices)
 
         if base == quote:
             return 1
@@ -354,6 +349,22 @@ class PricingMixin:
 
 
 pandas_coin_pair_attr = {DataFrame: "columns", Series: "index"}
+
+
+def get_coin_pairs(prices):
+    """
+    Returns the coin pairs available in the price data.
+    """
+    if isinstance(prices, DataFrame):
+        return prices.columns
+    if isinstance(prices, Series):
+        return prices.index
+    if isinstance(prices, dict):
+        return prices.keys()
+
+    raise MetricError(
+        f"Argument 'price' must be DataFrame, Series, or dict, not {type(prices)}"
+    )
 
 
 def get_numeraire(coins):

--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -24,7 +24,7 @@ from curvesim.pool.sim_interface import (
     SimCurvePool,
     SimCurveRaiPool,
 )
-from curvesim.utils import get_pairs
+from curvesim.utils import cache, get_pairs
 
 from .base import Metric, PoolMetric, PoolPricingMetric, PricingMetric
 
@@ -153,6 +153,7 @@ class PoolVolume(PoolPricingMetric):
     """
 
     @property
+    @cache
     def pool_config(self):
         base = {
             "functions": {"summary": {"pool_volume": "sum"}},
@@ -264,6 +265,7 @@ class PoolBalance(PoolMetric):
     """
 
     @property
+    @cache
     def pool_config(self):
         ss_config = {
             "functions": {
@@ -332,6 +334,7 @@ class PoolValue(PoolPricingMetric):
     """
 
     @property
+    @cache
     def pool_config(self):
         plot = {
             "metrics": {
@@ -521,6 +524,7 @@ class PriceDepth(PoolMetric):
     __slots__ = ["_factor"]
 
     @property
+    @cache
     def pool_config(self):
         ss_config = {
             "functions": {

--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -6,6 +6,7 @@ Specific metric classes for use in simulations.
 __all__ = [
     "ArbMetrics",
     "PoolBalance",
+    "PoolVolume",
     "PoolValue",
     "PriceDepth",
     "Timestamp",
@@ -17,7 +18,12 @@ from altair import Axis, Scale
 from numpy import array, exp, log, timedelta64
 from pandas import DataFrame, concat
 
-from curvesim.pool.sim_interface import SimCurveMetaPool, SimCurvePool, SimCurveRaiPool
+from curvesim.pool.sim_interface import (
+    SimCurveCryptoPool,
+    SimCurveMetaPool,
+    SimCurvePool,
+    SimCurveRaiPool,
+)
 from curvesim.utils import get_pairs
 
 from .base import Metric, PoolMetric, PoolPricingMetric, PricingMetric
@@ -141,7 +147,7 @@ class ArbMetrics(PricingMetric):
         return DataFrame(profit).set_index("timestamp")
 
 
-class PoolVolume(PoolMetric):
+class PoolVolume(PoolPricingMetric):
     """
     Records total trade volume for each timestamp.
     """
@@ -171,12 +177,24 @@ class PoolVolume(PoolMetric):
             SimCurvePool: self.get_stableswap_pool_volume,
             SimCurveMetaPool: self.get_stableswap_metapool_volume,
             SimCurveRaiPool: self.get_stableswap_metapool_volume,
+            SimCurveCryptoPool: self.get_cryptoswap_pool_volume,
+        }
+
+        units = {
+            SimCurvePool: "(of Any Coin)",
+            SimCurveMetaPool: "(of Any Coin)",
+            SimCurveRaiPool: "(of Any Coin)",
+            SimCurveCryptoPool: f"(in {self.numeraire})",
         }
 
         config = {}
-        for pool, fn in functions.items():
-            config[pool] = deepcopy(base)
-            config[pool]["functions"]["metrics"] = fn
+        for pool in functions:
+            cfg = deepcopy(base)
+            cfg["functions"]["metrics"] = functions[pool]
+            _units = units[pool]
+            cfg["plot"]["metrics"]["pool_volume"]["title"] = "Daily Volume " + _units
+            cfg["plot"]["summary"]["pool_volume"]["title"] = "Total Volume " + _units
+            config[pool] = cfg
 
         return config
 
@@ -186,7 +204,8 @@ class PoolVolume(PoolMetric):
         """
         trade_data = kwargs["trade_data"]
 
-        def per_timestamp_function(trades):
+        def per_timestamp_function(trade_data):
+            trades = trade_data.trades
             return sum(trade.amount_in for trade in trades) / 10**18
 
         return self._get_volume(trade_data, per_timestamp_function)
@@ -200,18 +219,39 @@ class PoolVolume(PoolMetric):
 
         meta_asset = self._pool.assets.symbols[0]
 
-        def per_timestamp_function(trades):
+        def per_timestamp_function(trade_data):
             volume = 0
-            for trade in trades:
+            for trade in trade_data.trades:
                 if meta_asset in (trade.coin_in, trade.coin_out):
                     volume += trade.amount_in
             return volume / 10**18
 
         return self._get_volume(trade_data, per_timestamp_function)
 
+    def get_cryptoswap_pool_volume(self, **kwargs):
+        """
+        Records trade volume for cryptoswap non-meta-pools.
+        """
+        trades = kwargs["trade_data"].trades
+        prices = kwargs["price_sample"].prices
+
+        trade_price_data = concat([trades, prices], axis=1)
+        numeraire = self.numeraire
+
+        def per_timestamp_function(trade_price_data):
+            trades = trade_price_data.trades
+            prices = trade_price_data.prices
+            get_price = self.get_market_price
+
+            volume = 0
+            for trade in trades:
+                volume += trade.amount_in * get_price(trade.coin_in, numeraire, prices)
+            return volume / 10**18
+
+        return self._get_volume(trade_price_data, per_timestamp_function)
+
     def _get_volume(self, trade_data, per_timestamp_function):
-        trades = trade_data.trades
-        volume = trades.apply(per_timestamp_function)
+        volume = trade_data.apply(per_timestamp_function, axis=1)
         results = DataFrame(volume)
         results.columns = ["pool_volume"]
         return results
@@ -227,7 +267,7 @@ class PoolBalance(PoolMetric):
     def pool_config(self):
         ss_config = {
             "functions": {
-                "metrics": self.get_stableswap_balance,
+                "metrics": self.get_pool_balance,
                 "summary": {"pool_balance": ["median", "min"]},
             },
             "plot": {
@@ -257,13 +297,14 @@ class PoolBalance(PoolMetric):
         }
 
         return dict.fromkeys(
-            [SimCurveMetaPool, SimCurvePool, SimCurveRaiPool], ss_config
+            [SimCurveMetaPool, SimCurvePool, SimCurveRaiPool, SimCurveCryptoPool],
+            ss_config,
         )
 
-    def get_stableswap_balance(self, **kwargs):
+    def get_pool_balance(self, **kwargs):
         """
         Computes pool balance metrics for each timestamp in an individual run.
-        Used for any stableswap pool.
+        Used for any Curve pool.
         """
         pool_state = kwargs["pool_state"]
         balance = pool_state.apply(self._compute_stableswap_balance, axis=1)
@@ -272,7 +313,7 @@ class PoolBalance(PoolMetric):
     def _compute_stableswap_balance(self, pool_state_row):
         """
         Computes balance metric for a single row of data (i.e., a single timestamp).
-        Used for any stableswap pool.
+        Used for any Curve pool.
         """
         self.set_pool_state(pool_state_row)
         pool = self._pool
@@ -292,7 +333,7 @@ class PoolValue(PoolPricingMetric):
 
     @property
     def pool_config(self):
-        ss_plot = {
+        plot = {
             "metrics": {
                 "pool_value_virtual": {
                     "title": "Pool Value (Virtual)",
@@ -319,45 +360,73 @@ class PoolValue(PoolPricingMetric):
             },
         }
 
-        ss_summary_fns = {
+        summary_fns = {
             "pool_value_virtual": {
                 "annualized_returns": self.compute_annualized_returns
             },
             "pool_value": {"annualized_returns": self.compute_annualized_returns},
         }
 
-        return {
-            SimCurvePool: {
-                "functions": {
-                    "metrics": self.get_stableswap_pool_value,
-                    "summary": ss_summary_fns,
-                },
-                "plot": ss_plot,
-            },
-            SimCurveMetaPool: {
-                "functions": {
-                    "metrics": self.get_stableswap_metapool_value,
-                    "summary": ss_summary_fns,
-                },
-                "plot": ss_plot,
-            },
-            SimCurveRaiPool: {
-                "functions": {
-                    "metrics": self.get_stableswap_metapool_value,
-                    "summary": ss_summary_fns,
-                },
-                "plot": ss_plot,
-            },
+        base = {
+            "functions": {"summary": summary_fns},
+            "plot": plot,
         }
+
+        functions = {
+            SimCurvePool: self.get_stableswap_pool_value,
+            SimCurveMetaPool: self.get_stableswap_metapool_value,
+            SimCurveRaiPool: self.get_stableswap_metapool_value,
+            SimCurveCryptoPool: self.get_cryptoswap_pool_value,
+        }
+
+        config = {}
+        for pool, fn in functions.items():
+            config[pool] = deepcopy(base)
+            config[pool]["functions"]["metrics"] = fn
+
+        return config
 
     def get_stableswap_pool_value(self, **kwargs):
         """
         Computes all metrics for each timestamp in an individual run.
         Used for non-meta stableswap pools.
         """
-        pool_state = kwargs["pool_state"]
-        price_sample = kwargs["price_sample"]
 
+        return self._get_pool_value(
+            kwargs["pool_state"],
+            kwargs["price_sample"],
+            self._get_stableswap_virtual_value,
+        )
+
+    def get_stableswap_metapool_value(self, **kwargs):
+        """
+        Computes all metrics for each timestamp in an individual run.
+        Used for stableswap metapools.
+        """
+
+        return self._get_metapool_value(
+            kwargs["pool_state"],
+            kwargs["price_sample"],
+            self._get_stableswap_virtual_value,
+        )
+
+    def get_cryptoswap_pool_value(self, **kwargs):
+        """
+        Computes all metrics for each timestamp in an individual run.
+        Used for non-meta cryptoswap pools.
+        """
+
+        return self._get_pool_value(
+            kwargs["pool_state"],
+            kwargs["price_sample"],
+            self._get_cryptoswap_virtual_value,
+        )
+
+    def _get_pool_value(self, pool_state, price_sample, virtual_price_fn):
+        """
+        Computes all metrics for each timestamp in an individual run.
+        Used for non-meta pools.
+        """
         reserves = DataFrame(
             pool_state.balances.to_list(),
             index=pool_state.index,
@@ -367,22 +436,17 @@ class PoolValue(PoolPricingMetric):
         prices = DataFrame(price_sample.prices.to_list(), index=price_sample.index)
 
         pool_value = self._get_value_from_prices(reserves / 10**18, prices)
-        pool_value_virtual = pool_state.apply(
-            self._get_stableswap_virtual_value, axis=1
-        )
+        pool_value_virtual = pool_state.apply(virtual_price_fn, axis=1)
 
         results = concat([pool_value_virtual, pool_value], axis=1)
         results.columns = list(self.config["plot"]["metrics"])
         return results.astype("float64")
 
-    def get_stableswap_metapool_value(self, **kwargs):
+    def _get_metapool_value(self, pool_state, price_sample, virtual_price_fn):
         """
         Computes all metrics for each timestamp in an individual run.
         Used for stableswap metapools.
         """
-        pool_state = kwargs["pool_state"]
-        price_sample = kwargs["price_sample"]
-
         max_coin = self._pool.max_coin
         pool = self._pool
 
@@ -405,9 +469,7 @@ class PoolValue(PoolPricingMetric):
         reserves = concat([meta_reserves.iloc[:, :max_coin], base_reserves], axis=1)
 
         pool_value = self._get_value_from_prices(reserves / 10**18, prices)
-        pool_value_virtual = pool_state.apply(
-            self._get_stableswap_virtual_value, axis=1
-        )
+        pool_value_virtual = pool_state.apply(virtual_price_fn, axis=1)
 
         results = concat([pool_value_virtual, pool_value], axis=1)
         results.columns = list(self.config["plot"]["metrics"])
@@ -433,6 +495,14 @@ class PoolValue(PoolPricingMetric):
         """
         self.set_pool_state(pool_state_row)
         return self._pool.D() / 10**18
+
+    def _get_cryptoswap_virtual_value(self, pool_state_row):
+        """
+        Computes virtual pool value for a single row of data (i.e., a single timestamp).
+        Used for any cryptoswap pool.
+        """
+        self.set_pool_state(pool_state_row)
+        return self._pool._get_xcp(self._pool.D) / 10**18
 
     def compute_annualized_returns(self, data):
         """Computes annualized returns from a series of pool values."""
@@ -478,7 +548,8 @@ class PriceDepth(PoolMetric):
         }
 
         return dict.fromkeys(
-            [SimCurveMetaPool, SimCurvePool, SimCurveRaiPool], ss_config
+            [SimCurveMetaPool, SimCurvePool, SimCurveRaiPool, SimCurveCryptoPool],
+            ss_config,
         )
 
     def __init__(self, pool, factor=10**8, **kwargs):

--- a/curvesim/metrics/results/__init__.py
+++ b/curvesim/metrics/results/__init__.py
@@ -4,5 +4,5 @@ Simulation results object and function to initialize it from simulation pipeline
 
 __all__ = ["SimResults", "make_results"]
 
-from .sim_results import SimResults
 from .make_results import make_results
+from .sim_results import SimResults

--- a/curvesim/metrics/state_log/pool_parameters.py
+++ b/curvesim/metrics/state_log/pool_parameters.py
@@ -1,17 +1,47 @@
+
 """
 Getters for pool parameters of different pool types.
 
 Used for the `StateLog`.
 """
-from curvesim.pool.sim_interface import SimCurveMetaPool, SimCurvePool, SimCurveRaiPool
+
+from curvesim.pool.sim_interface import (
+    SimCurveMetaPool,
+    SimCurvePool,
+    SimCurveRaiPool,
+    SimCurveCryptoPool,
+)
 
 
 def get_pool_parameters(pool):
     """
     Returns pool parameters for the input pool. Functions for each pool type are
-    specified in the `pool_parameter_functions` dict.
+    specified in the `pool_parameter_functions` dict. Returned values are recorded
+    at the start of each simulation run.
     """
     return pool_parameter_functions[type(pool)](pool)
+
+
+def get_cryptoswap_pool_params(pool):
+    """Returns pool parameters for cryptoswap non-meta pools."""
+    params = {
+        "A": pool.A,
+        "gamma": pool.gamma / 10**18,
+        "D": pool.D / 10**18,
+        "mid_fee": pool.mid_fee / 10**10,
+        "out_fee": pool.out_fee / 10**10,
+        "fee_gamma": pool.fee_gamma / 10**18,
+        "allowed_extra_profit": pool.allowed_extra_profit / 10**18,
+        "adjustment_step": pool.adjustment_step / 10**18,
+        "ma_half_time": pool.ma_half_time,
+    }
+
+    for param_name in ["admin_fee"]:
+        param_val = getattr(pool, param_name, None)
+        if param_val:
+            params.update({param_name: param_val / 10**10})
+
+    return params
 
 
 def get_stableswap_pool_params(pool):
@@ -43,4 +73,5 @@ pool_parameter_functions = {
     SimCurvePool: get_stableswap_pool_params,
     SimCurveMetaPool: get_stableswap_metapool_params,
     SimCurveRaiPool: get_stableswap_metapool_params,
+    SimCurveCryptoPool: get_cryptoswap_pool_params,
 }

--- a/curvesim/metrics/state_log/pool_parameters.py
+++ b/curvesim/metrics/state_log/pool_parameters.py
@@ -1,4 +1,3 @@
-
 """
 Getters for pool parameters of different pool types.
 
@@ -6,10 +5,10 @@ Used for the `StateLog`.
 """
 
 from curvesim.pool.sim_interface import (
+    SimCurveCryptoPool,
     SimCurveMetaPool,
     SimCurvePool,
     SimCurveRaiPool,
-    SimCurveCryptoPool,
 )
 
 

--- a/curvesim/metrics/state_log/pool_parameters.py
+++ b/curvesim/metrics/state_log/pool_parameters.py
@@ -4,6 +4,7 @@ Getters for pool parameters of different pool types.
 Used for the `StateLog`.
 """
 
+from curvesim.exceptions import UnregisteredPoolError
 from curvesim.pool.sim_interface import (
     SimCurveCryptoPool,
     SimCurveMetaPool,
@@ -18,7 +19,12 @@ def get_pool_parameters(pool):
     specified in the `pool_parameter_functions` dict. Returned values are recorded
     at the start of each simulation run.
     """
-    return pool_parameter_functions[type(pool)](pool)
+    try:
+        return pool_parameter_functions[type(pool)](pool)
+    except KeyError as e:
+        raise UnregisteredPoolError(
+            f"Parameter getter not implemented for pool type '{type(pool)}'."
+        ) from e
 
 
 def get_cryptoswap_pool_params(pool):

--- a/curvesim/metrics/state_log/pool_state.py
+++ b/curvesim/metrics/state_log/pool_state.py
@@ -1,8 +1,8 @@
 from curvesim.pool.sim_interface import (
+    SimCurveCryptoPool,
     SimCurveMetaPool,
     SimCurvePool,
     SimCurveRaiPool,
-    SimCurveCryptoPool,
 )
 
 

--- a/curvesim/metrics/state_log/pool_state.py
+++ b/curvesim/metrics/state_log/pool_state.py
@@ -1,3 +1,4 @@
+from curvesim.exceptions import UnregisteredPoolError
 from curvesim.pool.sim_interface import (
     SimCurveCryptoPool,
     SimCurveMetaPool,
@@ -12,7 +13,12 @@ def get_pool_state(pool):
     specified in the `pool_state_functions` dict. Each function returns the
     values necessary to reconstruct pool state throughout a simulation run.
     """
-    return pool_state_functions[type(pool)](pool)
+    try:
+        return pool_state_functions[type(pool)](pool)
+    except KeyError as e:
+        raise UnregisteredPoolError(
+            f"State getter not implemented for pool type '{type(pool)}'."
+        ) from e
 
 
 def get_cryptoswap_pool_state(pool):

--- a/curvesim/metrics/state_log/pool_state.py
+++ b/curvesim/metrics/state_log/pool_state.py
@@ -1,12 +1,33 @@
-from curvesim.pool.sim_interface import SimCurveMetaPool, SimCurvePool, SimCurveRaiPool
+from curvesim.pool.sim_interface import (
+    SimCurveMetaPool,
+    SimCurvePool,
+    SimCurveRaiPool,
+    SimCurveCryptoPool,
+)
 
 
 def get_pool_state(pool):
     """
     Returns pool state for the input pool. Functions for each pool type are
-    specified in the `pool_state_functions` dict.
+    specified in the `pool_state_functions` dict. Each function returns the
+    values necessary to reconstruct pool state throughout a simulation run.
     """
     return pool_state_functions[type(pool)](pool)
+
+
+def get_cryptoswap_pool_state(pool):
+    """Returns pool state for stableswap non-meta pools."""
+    return {
+        "balances": pool.balances,
+        "tokens": pool.tokens,
+        "price_scale": pool.price_scale,
+        "price_oracle": pool.price_oracle(),
+        "xcp_profit": pool.xcp_profit,
+        "xcp_profit_a": pool.xcp_profit_a,
+        "last_prices": pool.last_prices,
+        "last_prices_timestamp": pool.last_prices_timestamp,
+        "not_adjusted": pool.not_adjusted,
+    }
 
 
 def get_stableswap_pool_state(pool):
@@ -31,4 +52,5 @@ pool_state_functions = {
     SimCurvePool: get_stableswap_pool_state,
     SimCurveMetaPool: get_stableswap_metapool_state,
     SimCurveRaiPool: get_stableswap_metapool_state,
+    SimCurveCryptoPool: get_cryptoswap_pool_state,
 }

--- a/test/fixtures/sim_pools.py
+++ b/test/fixtures/sim_pools.py
@@ -1,11 +1,11 @@
-from pandas import DataFrame
 import pytest
+from pandas import DataFrame
 
 from curvesim.pool.sim_interface import (
+    SimCurveCryptoPool,
+    SimCurveMetaPool,
     SimCurvePool,
     SimCurveRaiPool,
-    SimCurveMetaPool,
-    SimCurveCryptoPool,
 )
 
 

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -1,0 +1,146 @@
+from copy import deepcopy
+
+import pytest
+from pandas import DataFrame, Series
+
+from curvesim.exceptions import MetricError
+from curvesim.metrics import init_metrics, metrics
+from curvesim.metrics.base import Metric, PoolMetric, PricingMetric, get_coin_pairs
+
+all_metrics = [getattr(metrics, m) for m in metrics.__all__]
+
+
+def test_init_metrics(
+    sim_curve_pool, sim_curve_crypto_pool, sim_curve_meta_pool, sim_curve_rai_pool
+):
+    """Test that all metrics successfully initialize with correct attributes/properties."""
+
+    pools = [
+        sim_curve_pool,
+        sim_curve_crypto_pool,
+        sim_curve_meta_pool,
+        sim_curve_rai_pool,
+    ]
+
+    coin_names = ["COIN0", "COIN1"]
+    coin_addresses = ["0x0", "0x1"]
+    prices = {("COIN0", "COIN1"): 10}
+
+    metadata = {
+        "coins": {
+            "names": coin_names,
+            "addresses": coin_addresses,
+        },
+        "chain": "mainnet",
+    }
+
+    basepool_metadata = {
+        "coins": {
+            "names": [coin_names[-1]],
+            "addresses": [coin_addresses[-1]],
+        },
+        "chain": "mainnet",
+    }
+
+    for pool in pools:
+        # Set metadata
+        pool.metadata = metadata
+        if hasattr(pool, "basepool"):
+            pool.basepool.metadata = basepool_metadata
+
+        # Loop through metric tests
+        metrics = init_metrics(all_metrics, pool=pool)
+        for metric in metrics:
+            _test_metric_class_init(metric)
+
+            if isinstance(metric, PoolMetric):
+                _test_pool_metric_class_init(metric, pool)
+
+            if isinstance(metric, PricingMetric):
+                _test_pricing_metric_class_init(metric, coin_names, prices)
+
+
+def _test_metric_class_init(metric):
+    """Test correct mapping of properties for Metric (sub)class."""
+    assert metric.metric_function == metric.config["functions"]["metrics"]
+    assert metric.plot_config == metric.config.get("plot", None)
+    assert metric.summary_functions == metric.config["functions"].get("summary", None)
+
+
+def _test_pool_metric_class_init(metric, pool):
+    """Test properties and methods specific to PoolMetric (sub)class."""
+
+    # Test properties
+    assert metric._pool == pool
+    assert metric.config == metric.pool_config[type(pool)]
+
+    # Test set_pool
+    pool_copy = deepcopy(pool)
+    metric.set_pool(pool_copy)
+    assert metric._pool == pool_copy
+    assert metric._pool != pool
+
+    # Test set_pool_state
+    metric.set_pool_state({"A": 0})
+    assert metric._pool.A == 0
+    if hasattr(pool, "basepool"):
+        metric.set_pool_state({"A_base": 0})
+        assert metric._pool.basepool.A == 0
+
+
+def _test_pricing_metric_class_init(metric, coin_names, prices):
+    """Test attributes and methods specific to PricingMetric (sub)class."""
+
+    # Test PricingMetric attributes
+    assert metric.coin_names == coin_names
+    assert metric.numeraire == coin_names[0]
+
+    # Test get_market_price
+    assert metric.get_market_price("COIN0", "COIN1", prices) == 10
+    assert metric.get_market_price("COIN1", "COIN0", prices) == 1 / 10
+
+
+def test_get_poin_pairs():
+    """Test that get_coin_pairs returns same results regardless of input format."""
+    price_dict = {("COIN0", "COIN1"): 10}
+    price_df = DataFrame.from_records([price_dict])
+    price_df2 = DataFrame.from_records([price_dict, price_dict])
+    price_series = Series(price_dict)
+
+    formats = [price_dict, price_df, price_df2, price_series]
+
+    for i in range(len(formats) - 1):
+        format1 = get_coin_pairs(formats[i])
+        format2 = get_coin_pairs(formats[i + 1])
+        assert format1 == format2
+        assert type(format1) == type(format2)
+
+
+def test_get_coin_pairs_wrong_type():
+    """Test that unsupported input type raises error."""
+    inputs = ["123", 123, [1, 2, 3], (1, 2, 3), {1, 2, 3}]
+
+    for inp in inputs:
+        with pytest.raises(MetricError):
+            get_coin_pairs(inp)
+
+
+def test_missing_metric_function_exception():
+    """Test that metric with no metric_function raises error."""
+
+    class WorkingDummyMetric(Metric):
+        @property
+        def config(self):
+            return {"functions": {"metrics": "working_function"}}
+
+    class BrokenDummyMetric(Metric):
+        @property
+        def config(self):
+            return {"functions": {}}
+
+    metric1 = WorkingDummyMetric()
+    metric2 = BrokenDummyMetric()
+
+    assert metric1.metric_function == "working_function"
+    with pytest.raises(MetricError):
+        metric2.metric_function

--- a/test/unit/test_state_log.py
+++ b/test/unit/test_state_log.py
@@ -1,0 +1,166 @@
+import pytest
+
+from curvesim.exceptions import UnregisteredPoolError
+from curvesim.metrics.state_log.pool_parameters import get_pool_parameters
+from curvesim.metrics.state_log.pool_state import get_pool_state
+
+# To Do: Currently only get_pool_parameters/get_pool_state are tested.
+
+
+def test_get_pool_parameters_curve_pool(sim_curve_pool):
+    """Test that get_pool_parameters returns the right data for SimCurvePool."""
+    pool = sim_curve_pool
+
+    expected_params = {
+        "A": pool.A,
+        "D": pool.D() / 10**18,
+        "fee": pool.fee / 10**10,
+        "admin_fee": pool.admin_fee / 10**10,
+    }
+
+    params = get_pool_parameters(pool)
+    assert params == expected_params
+
+    # Test with fee_mul
+    pool.fee_mul = 2 * 10**10
+    expected_params["fee_mul"] = 2
+    params = get_pool_parameters(pool)
+    assert params == expected_params
+
+
+def test_get_pool_parameters_curve_crypto_pool(sim_curve_crypto_pool):
+    """Test that get_pool_parameters returns the right data for SimCurveCryptoPool."""
+    pool = sim_curve_crypto_pool
+
+    expected_params = {
+        "A": pool.A,
+        "gamma": pool.gamma / 10**18,
+        "D": pool.D / 10**18,
+        "mid_fee": pool.mid_fee / 10**10,
+        "out_fee": pool.out_fee / 10**10,
+        "fee_gamma": pool.fee_gamma / 10**18,
+        "allowed_extra_profit": pool.allowed_extra_profit / 10**18,
+        "adjustment_step": pool.adjustment_step / 10**18,
+        "ma_half_time": pool.ma_half_time,
+        "admin_fee": pool.admin_fee / 10**10,
+    }
+
+    params = get_pool_parameters(pool)
+    assert params == expected_params
+
+
+def test_get_pool_parameters_curve_meta_pool(sim_curve_meta_pool):
+    """Test that get_pool_parameters returns the right data for SimCurveMetaPool."""
+    _test_get_pool_parameters_curve_meta_pool(sim_curve_meta_pool)
+
+
+def test_get_pool_parameters_curve_rai_pool(sim_curve_rai_pool):
+    """Test that get_pool_parameters returns the right data for SimCurveRaiPool."""
+    _test_get_pool_parameters_curve_meta_pool(sim_curve_rai_pool)
+
+
+def _test_get_pool_parameters_curve_meta_pool(pool):
+    expected_params = {
+        "A": pool.A,
+        "D": pool.D() / 10**18,
+        "fee": pool.fee / 10**10,
+        "admin_fee": pool.admin_fee / 10**10,
+        "A_base": pool.basepool.A,
+        "D_base": pool.basepool.D() / 10**18,
+        "fee_base": pool.basepool.fee / 10**10,
+        "admin_fee_base": pool.basepool.admin_fee / 10**10,
+    }
+
+    params = get_pool_parameters(pool)
+    assert params == expected_params
+
+    # Test with fee_mul
+    pool.fee_mul = 2 * 10**10
+    pool.basepool.fee_mul = 3 * 10**10
+    expected_params["fee_mul"] = 2
+    expected_params["fee_mul_base"] = 3
+
+    params = get_pool_parameters(pool)
+    assert params == expected_params
+
+
+def test_get_pool_parameters_unmapped_exception():
+    """Test that unmapped pool throws error."""
+
+    class DummyPool:
+        pass
+
+    pool = DummyPool()
+
+    with pytest.raises(UnregisteredPoolError):
+        get_pool_parameters(pool)
+
+
+def test_get_pool_state_curve_pool(sim_curve_pool):
+    """Test that get_pool_state returns the right data for SimCurvePool."""
+    pool = sim_curve_pool
+
+    expected_state = {
+        "balances": pool.balances,
+        "tokens": pool.tokens,
+        "admin_balances": pool.admin_balances,
+    }
+
+    state = get_pool_state(pool)
+    assert state == expected_state
+
+
+def test_get_pool_state_curve_crypto_pool(sim_curve_crypto_pool):
+    """Test that get_pool_state returns the right data for SimCurveCryptoPool."""
+    pool = sim_curve_crypto_pool
+
+    expected_state = {
+        "balances": pool.balances,
+        "tokens": pool.tokens,
+        "price_scale": pool.price_scale,
+        "price_oracle": pool.price_oracle(),
+        "xcp_profit": pool.xcp_profit,
+        "xcp_profit_a": pool.xcp_profit_a,
+        "last_prices": pool.last_prices,
+        "last_prices_timestamp": pool.last_prices_timestamp,
+        "not_adjusted": pool.not_adjusted,
+    }
+
+    state = get_pool_state(pool)
+    assert state == expected_state
+
+
+def test_get_pool_state_curve_meta_pool(sim_curve_meta_pool):
+    """Test that get_pool_state returns the right data for SimCurveMetaPool."""
+    _test_get_pool_state_curve_meta_pool(sim_curve_meta_pool)
+
+
+def test_get_pool_state_curve_rai_pool(sim_curve_rai_pool):
+    """Test that get_pool_state returns the right data for SimCurveRaiPool."""
+    _test_get_pool_state_curve_meta_pool(sim_curve_rai_pool)
+
+
+def _test_get_pool_state_curve_meta_pool(pool):
+    expected_state = {
+        "balances": pool.balances,
+        "tokens": pool.tokens,
+        "admin_balances": pool.admin_balances,
+        "balances_base": pool.basepool.balances,
+        "tokens_base": pool.basepool.tokens,
+        "admin_balances_base": pool.basepool.admin_balances,
+    }
+
+    state = get_pool_state(pool)
+    assert state == expected_state
+
+
+def test_get_pool_state_unmapped_exception():
+    """Test that unmapped pool throws StateLogError."""
+
+    class DummyPool:
+        pass
+
+    pool = DummyPool()
+
+    with pytest.raises(UnregisteredPoolError):
+        get_pool_state(pool)


### PR DESCRIPTION
### Description
This PR incorporates SimCurveCryptoPool into the metrics framework, including the StateLog and all pool-specific metrics. 

It addresses the item "metrics framework needs updating: getters, PoolBalance needs to incorporate price, PoolValue needs to use xcp(D)" in #96 

Specific changes/additions:
- incorporate SimCurveCryptoPool into required metrics
- add tests for get_pool_parameters, get_pool_state, each metric class
- metrics.state_log: Add get_pool_parameters and get_pool_state functions for SimCurveCryptoPool

### Note
I added basic tests for each metric to ensure that all the base class properties/attributes/methods work correctly. I did not add unit tests for any of the specific metrics in metrics.metrics, although these are exercised in the end-to-end tests. Those will take some further thought/discussion on how best to test without simply duplicating the code. For the pool-specific CryptoPool metrics, running some simulations may help to reveal any issues.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/9f/96/4e/9f964eb8c737fa4184cc8f827220e3bf.jpg)
