### PR TITLE
Get in amount

### DIFF
--- a/changelog.d/20230802_174720_chanhosuh_get_in_amount.rst
+++ b/changelog.d/20230802_174720_chanhosuh_get_in_amount.rst
@@ -1,0 +1,7 @@
+Added
+-----
+
+- Added `get_y` to `CurveCryptoPool` as with the stableswap pools.
+  This breaks tight adherence to the vyper interface, but makes it easier
+  for integrators.
+

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -500,6 +500,41 @@ class CurveCryptoPool(Pool):
 
         return dy
 
+    def get_y(self, i, j, x, xp):
+        r"""
+        Calculate x[j] if one makes x[i] = x.
+
+        Parameters
+        ----------
+        i: int
+            index of coin; usually the "in"-token
+        j: int
+            index of coin; usually the "out"-token
+        x: int
+            balance of i-th coin in units of D
+        xp: list of int
+            coin balances in units of D
+
+        Returns
+        -------
+        int
+            The balance of the j-th coin, in units of D, for the other
+            coin balances given.
+
+        Note
+        ----
+        This is a "view" function; it doesn't change the state of the pool.
+        """
+        A: int = self.A
+        gamma: int = self.gamma
+        D: int = _newton_D(A, gamma, xp)
+
+        xp = xp.copy()
+        xp[i] = x
+
+        y, _ = _get_y(A, gamma, xp, D, j)
+        return y
+
     def _fee(self, xp: List[int]) -> int:
         """
         f = fee_gamma / (fee_gamma + (1 - K))

--- a/curvesim/pool/sim_interface/cryptoswap.py
+++ b/curvesim/pool/sim_interface/cryptoswap.py
@@ -117,22 +117,13 @@ class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
             An approximate quantity to swap to achieve the target out-token
             balance
         """
-        raise SimPoolError("`get_in_amount` not implemented for SimCurveCryptoPool.")
-        # i, j = self.get_asset_indices(coin_in, coin_out)
+        i, j = self.get_asset_indices(coin_in, coin_out)
 
-        # The cryptoswap (dynamic) fee is calculated on the state `xp`,
-        # which has been adjusted by increasing in-token balance and
-        # decreasing out-token balance.
-        #
-        # This means we can't just back out the `in_amount` using `get_y`
-        # as with stableswap (fixed fee).
-        #
-        # We can use the following get_dx helper function:
-        # https://github.com/curvefi/tricrypto-ng/blob/main/contracts/main/CurveCryptoViews3Optimized.vy#L183
-        # Tricrypto-ng uses this 5 times in a loop, we may want to increase the
-        # number of iterations.
+        xp = self._xp()
+        xp_j = int(xp[j] * out_balance_perc)
 
-        # return in_amount
+        in_amount = self.get_y(j, i, xp_j, xp) - xp[i]
+        return in_amount
 
     @property
     @override

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -337,6 +337,36 @@ def test__get_y(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     assert y_out[1] == expected_y_out[1]
 
 
+def test_get_y(vyper_tricrypto):
+    """
+    Test `get_y`.
+
+    Note `_get_y`, which is the pure version, is already tested
+    thoroughly in its own test against the vyper.
+
+    This test is a sanity check to make sure we pass values in correctly
+    to the underlying `_get_y` implementation.
+    """
+    pool = initialize_pool(vyper_tricrypto)
+
+    xp = pool._xp()
+    A = pool.A
+    gamma = pool.gamma
+    D = _newton_D(A, gamma, xp)
+
+    i = 0
+    j = 1
+
+    # `get_y` will set i-th balance to `x`
+    x = xp[i] * 102 // 100
+    y = pool.get_y(i, j, x, xp)
+
+    xp[i] = x
+    expected_y, _ = _get_y(A, gamma, xp, D, j)
+
+    assert y == expected_y
+
+
 @given(st.integers(min_value=-42139678854452767551, max_value=135305999368893231589))
 @settings(
     suppress_health_check=[HealthCheck.function_scoped_fixture],

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -18,6 +18,7 @@ from curvesim.pool.cryptoswap.calcs.tricrypto_ng import (
     MIN_GAMMA,
     PRECISION,
 )
+from curvesim.pool.cryptoswap.pool import _get_y, _newton_D
 
 
 def get_math(tricrypto):
@@ -250,7 +251,7 @@ def test_multiple_exchange_with_repeg(
     max_examples=5,
     deadline=None,
 )
-def test_newton_D(vyper_tricrypto, A, gamma, x0, x1, x2):
+def test__newton_D(vyper_tricrypto, A, gamma, x0, x1, x2):
     """Test D calculation against vyper implementation."""
 
     xp = [x0, x1, x2]
@@ -261,7 +262,7 @@ def test_newton_D(vyper_tricrypto, A, gamma, x0, x1, x2):
     MATH = get_math(vyper_tricrypto)
     # pylint: disable=no-member
     expected_D = MATH.newton_D(A, gamma, xp)
-    D = tricrypto_ng.newton_D(A, gamma, xp)
+    D = _newton_D(A, gamma, xp)
 
     assert D == expected_D
 
@@ -314,7 +315,7 @@ def test_get_p(vyper_tricrypto, A, gamma, x0, x1, x2):
     max_examples=5,
     deadline=None,
 )
-def test_get_y(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
+def test__get_y(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     """Test D calculation against vyper implementation."""
     i, j = pair
 
@@ -330,7 +331,7 @@ def test_get_y(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     xp[i] += xp[i] * dx_perc // 10000
 
     expected_y_out = MATH.get_y(A, gamma, xp, D, j)
-    y_out = tricrypto_ng.get_y(A, gamma, xp, D, j)
+    y_out = _get_y(A, gamma, xp, D, j)
 
     assert y_out[0] == expected_y_out[0]
     assert y_out[1] == expected_y_out[1]


### PR DESCRIPTION
### Description

Implement `get_in_amount` for `SimCurveCryptoPool`.

Closes #179.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1560114928-40f1f1eb26a0?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y3V0ZSUyMGFuaW1hbHxlbnwwfHwwfHx8MA%3D%3D&auto=format&fit=crop&w=500&q=60)
