### PR TITLE
`AssetIndicesMixin` `asset_names` setter and tests

### DIFF
--- a/curvesim/pool/base.py
+++ b/curvesim/pool/base.py
@@ -53,7 +53,7 @@ class Pool(SnapshotMixin):
 
     @property
     def coin_decimals(self):
-        """Addresses for the pool coins."""
+        """Decimal precisions for the pool coins."""
         if hasattr(self, "metadata"):
             return self.metadata["coins"]["decimals"]
         return []

--- a/curvesim/pool/sim_interface/asset_indices.py
+++ b/curvesim/pool/sim_interface/asset_indices.py
@@ -22,7 +22,7 @@ class AssetIndicesMixin:
         # -> AssetIndicesMixin children (SimPools) call their implementations in __init__ with a copy() of metadata
         # -> setter sets an attribute _asset_names to input array after passing checks
 
-    # asset_balances check:
+    # both arrays are equal length check:
         # in asset_balances below
 
     @property
@@ -37,11 +37,11 @@ class AssetIndicesMixin:
 
     @asset_names.setter
     @abstractmethod
-    def asset_names(self, *asset_names):
+    def asset_names(self, **kwargs):
         """
         Set list of asset names. 
         
-        Implementations should disallow setting duplicate names.
+        Implementations should disallow setting duplicate names and inconsistent numbers of names.
         """
         raise NotImplementedError
 

--- a/curvesim/pool/sim_interface/asset_indices.py
+++ b/curvesim/pool/sim_interface/asset_indices.py
@@ -11,6 +11,7 @@ class AssetIndicesMixin:
     Used in both stableswap and cryptoswap implementations used
     in arbitrage pipelines.
     """
+
     @property
     @abstractmethod
     def asset_names(self):
@@ -41,7 +42,9 @@ class AssetIndicesMixin:
     def asset_balances(self):
         """Return dict mapping asset names to coin balances."""
         if len(self.asset_names) != len(self._asset_balances):
-            raise CurvesimException("Number of symbols and number of balances aren't the same.")
+            raise CurvesimException(
+                "Number of symbols and number of balances aren't the same."
+            )
 
         return dict(zip(self.asset_names, self._asset_balances))
 

--- a/curvesim/pool/sim_interface/asset_indices.py
+++ b/curvesim/pool/sim_interface/asset_indices.py
@@ -12,6 +12,19 @@ class AssetIndicesMixin:
     in arbitrage pipelines.
     """
 
+    # we want to enforce valid inputs for asset_names and _asset_balances. 
+        # both arrays are equal length
+        # no duplicates in asset_names specifically
+    
+    # asset_names check:
+        # -> SimPools automatically load metadata
+        # -> add abstract asset_names.setter
+        # -> AssetIndicesMixin children (SimPools) call their implementations in __init__ with a copy() of metadata
+        # -> setter sets an attribute _asset_names to input array after passing checks
+
+    # asset_balances check:
+        # in asset_balances below
+
     @property
     @abstractmethod
     def asset_names(self):
@@ -19,6 +32,16 @@ class AssetIndicesMixin:
         Return list of asset names.
 
         For metapools, our convention is to place the basepool LP token last.
+        """
+        raise NotImplementedError
+
+    @asset_names.setter
+    @abstractmethod
+    def asset_names(self, *asset_names):
+        """
+        Set list of asset names. 
+        
+        Implementations should disallow setting duplicate names.
         """
         raise NotImplementedError
 
@@ -31,6 +54,8 @@ class AssetIndicesMixin:
     @property
     def asset_balances(self):
         """Return dict mapping asset names to coin balances."""
+
+        # check equal length 
         return dict(zip(self.asset_names, self._asset_balances))
 
     @property

--- a/curvesim/pool/sim_interface/asset_indices.py
+++ b/curvesim/pool/sim_interface/asset_indices.py
@@ -12,18 +12,18 @@ class AssetIndicesMixin:
     in arbitrage pipelines.
     """
 
-    # we want to enforce valid inputs for asset_names and _asset_balances. 
-        # both arrays are equal length
-        # no duplicates in asset_names specifically
-    
+    # we want to enforce valid inputs for asset_names and _asset_balances.
+    # both arrays are equal length
+    # no duplicates in asset_names specifically
+
     # asset_names check:
-        # -> SimPools automatically load metadata
-        # -> add abstract asset_names.setter
-        # -> AssetIndicesMixin children (SimPools) call their implementations in __init__ with a copy() of metadata
-        # -> setter sets an attribute _asset_names to input array after passing checks
+    # -> SimPools automatically load metadata
+    # -> add abstract asset_names.setter
+    # -> AssetIndicesMixin children (SimPools) call their implementations in __init__ with a copy() of metadata
+    # -> setter sets an attribute _asset_names to input array after passing checks
 
     # both arrays are equal length check:
-        # in asset_balances below
+    # in asset_balances below
 
     @property
     @abstractmethod
@@ -39,8 +39,8 @@ class AssetIndicesMixin:
     @abstractmethod
     def asset_names(self, *asset_lists):
         """
-        Set list of asset names. 
-        
+        Set list of asset names.
+
         Implementations should disallow setting of duplicate names and inconsistent numbers of names.
         """
         raise NotImplementedError
@@ -55,7 +55,7 @@ class AssetIndicesMixin:
     def asset_balances(self):
         """Return dict mapping asset names to coin balances."""
 
-        # check equal length 
+        # check equal length
         return dict(zip(self.asset_names, self._asset_balances))
 
     @property

--- a/curvesim/pool/sim_interface/asset_indices.py
+++ b/curvesim/pool/sim_interface/asset_indices.py
@@ -1,7 +1,7 @@
 """Base SimPool implementation for Curve stableswap pools, both regular and meta."""
 from abc import abstractmethod
 
-from curvesim.exceptions import CurvesimValueError
+from curvesim.exceptions import CurvesimException, CurvesimValueError
 from curvesim.utils import cache
 
 
@@ -11,20 +11,6 @@ class AssetIndicesMixin:
     Used in both stableswap and cryptoswap implementations used
     in arbitrage pipelines.
     """
-
-    # we want to enforce valid inputs for asset_names and _asset_balances.
-    # both arrays are equal length
-    # no duplicates in asset_names specifically
-
-    # asset_names check:
-    # -> SimPools automatically load metadata
-    # -> add abstract asset_names.setter
-    # -> AssetIndicesMixin children (SimPools) call their implementations in __init__ with a copy() of metadata
-    # -> setter sets an attribute _asset_names to input array after passing checks
-
-    # both arrays are equal length check:
-    # in asset_balances below
-
     @property
     @abstractmethod
     def asset_names(self):
@@ -54,8 +40,9 @@ class AssetIndicesMixin:
     @property
     def asset_balances(self):
         """Return dict mapping asset names to coin balances."""
+        if len(self.asset_names) != len(self._asset_balances):
+            raise CurvesimException("Number of symbols and number of balances aren't the same.")
 
-        # check equal length
         return dict(zip(self.asset_names, self._asset_balances))
 
     @property

--- a/curvesim/pool/sim_interface/asset_indices.py
+++ b/curvesim/pool/sim_interface/asset_indices.py
@@ -37,11 +37,11 @@ class AssetIndicesMixin:
 
     @asset_names.setter
     @abstractmethod
-    def asset_names(self, **kwargs):
+    def asset_names(self, *asset_lists):
         """
         Set list of asset names. 
         
-        Implementations should disallow setting duplicate names and inconsistent numbers of names.
+        Implementations should disallow setting of duplicate names and inconsistent numbers of names.
         """
         raise NotImplementedError
 

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -65,7 +65,7 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
             raise SimPoolError("SimCurveMetaPool must have a consistent number of metapool asset names and basepool asset names, separately.")
 
         self._asset_names = asset_names
-        self._basepool_asset_names = basepoolasset_names_asset_names
+        self._basepool_asset_names = basepool_asset_names
 
     @property
     @override

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -39,6 +39,11 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
 
         return [*meta_coin_names, *base_coin_names, bp_token_name]
 
+    @asset_names.setter
+    @override
+    def asset_names(self, *asset_names):
+        pass
+
     @property
     @override
     def _asset_balances(self):

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -11,10 +11,7 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.asset_names(
-            asset_names=self.coin_names, 
-            basepool_asset_names=self.basepool.coin_names,
-        )
+        self.asset_names = self.coin_names, self.basepool.coin_names
 
         # The rates check has a couple special cases:
         # 1. For metapools, we need to use the basepool rates
@@ -38,34 +35,34 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
 
         For metapools, our convention is to place the basepool LP token last.
         """
-        meta_coin_names = self._asset_names[:-1]
-        base_coin_names = self._basepool_asset_names
-        bp_token_name = self._asset_names[-1]
+        meta_coin_names = self._metapool_names[:-1]
+        base_coin_names = self._basepool_names
+        bp_token_name = self._metapool_names[-1]
 
         return [*meta_coin_names, *base_coin_names, bp_token_name]
 
     @asset_names.setter
     @override
-    def asset_names(self, **kwargs):
+    def asset_names(self, *asset_lists):
         """
         Set list of asset names.
 
-        Keywords:
+        Positional args:
 
-        asset_names: list of all metapool asset names.
-        basepool_asset_names: list of all basepool asset names.
+        [0]: list of all metapool asset names.
+        [1]: list of all basepool asset names.
         """
-        asset_names = kwargs["asset_names"].copy()
-        basepool_asset_names = kwargs["basepool_asset_names"].copy()
+        metapool_names = asset_lists[0].copy()
+        basepool_names = asset_lists[1].copy()
 
-        if len(asset_names) != len(set(asset_names)) or len(basepool_asset_names) != len(set(basepool_asset_names)):
+        if len(metapool_names) != len(set(metapool_names)) or len(basepool_names) != len(set(basepool_names)):
             raise SimPoolError("SimCurveMetaPool must have unique asset names for metapool and basepool, separately.")
 
-        if hasattr(self, "asset_names") and (len(self._asset_names) != len(asset_names) or len(self._basepool_asset_names) != len(basepool_asset_names)):
+        if hasattr(self, "asset_names") and (len(self._metapool_names) != len(metapool_names) or len(self._basepool_names) != len(basepool_names)):
             raise SimPoolError("SimCurveMetaPool must have a consistent number of metapool asset names and basepool asset names, separately.")
 
-        self._asset_names = asset_names
-        self._basepool_asset_names = basepool_asset_names
+        self._metapool_names = metapool_names
+        self._basepool_names = basepool_names
 
     @property
     @override
@@ -159,7 +156,7 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
     @override
     @cache
     def assets(self):
-        symbols = self._asset_names[:-1] + self._basepool_asset_names
+        symbols = self._metapool_names[:-1] + self._basepool_names
         addresses = self.coin_addresses[:-1] + self.basepool.coin_addresses
 
         return SimAssets(symbols, addresses, self.chain)

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -55,11 +55,20 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
         metapool_names = asset_lists[0].copy()
         basepool_names = asset_lists[1].copy()
 
-        if len(metapool_names) != len(set(metapool_names)) or len(basepool_names) != len(set(basepool_names)):
-            raise SimPoolError("SimCurveMetaPool must have unique asset names for metapool and basepool, separately.")
+        if len(metapool_names) != len(set(metapool_names)) or len(
+            basepool_names
+        ) != len(set(basepool_names)):
+            raise SimPoolError(
+                "SimCurveMetaPool must have unique asset names for metapool and basepool, separately."
+            )
 
-        if hasattr(self, "asset_names") and (len(self._metapool_names) != len(metapool_names) or len(self._basepool_names) != len(basepool_names)):
-            raise SimPoolError("SimCurveMetaPool must have a consistent number of metapool asset names and basepool asset names, separately.")
+        if hasattr(self, "asset_names") and (
+            len(self._metapool_names) != len(metapool_names)
+            or len(self._basepool_names) != len(basepool_names)
+        ):
+            raise SimPoolError(
+                "SimCurveMetaPool must have a consistent number of metapool asset names and basepool asset names, separately."
+            )
 
         self._metapool_names = metapool_names
         self._basepool_names = basepool_names

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -13,7 +13,7 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
 
         self.asset_names(
             asset_names=self.coin_names, 
-            basepool_asset_names=self.basepool.coin_names
+            basepool_asset_names=self.basepool.coin_names,
         )
 
         # The rates check has a couple special cases:

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -68,7 +68,8 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
             or len(self._basepool_names) != len(basepool_names)
         ):
             raise SimPoolError(
-                "SimCurveMetaPool must have a consistent number of metapool asset names and basepool asset names, separately."
+                "SimCurveMetaPool must have a consistent number of metapool asset names and \
+                    basepool asset names, separately."
             )
 
         if not hasattr(self, "asset_names"):

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -48,12 +48,13 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
         Set list of asset names.
 
         Positional args:
+        ----------------
 
         [0]: list of all metapool asset names.
         [1]: list of all basepool asset names.
         """
-        metapool_names = asset_lists[0].copy()
-        basepool_names = asset_lists[1].copy()
+        metapool_names = asset_lists[0]
+        basepool_names = asset_lists[1]
 
         if len(metapool_names) != len(set(metapool_names)) or len(
             basepool_names
@@ -70,8 +71,15 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
                 "SimCurveMetaPool must have a consistent number of metapool asset names and basepool asset names, separately."
             )
 
-        self._metapool_names = metapool_names
-        self._basepool_names = basepool_names
+        if not hasattr(self, "asset_names"):
+            self._metapool_names = [str()] * len(metapool_names)
+            self._basepool_names = [str()] * len(basepool_names)
+
+        for i in range(len(metapool_names)):
+            self._metapool_names[i] = metapool_names[i]
+            
+        for i in range(len(basepool_names)):
+            self._basepool_names[i] = basepool_names[i]
 
     @property
     @override

--- a/curvesim/pool/sim_interface/metapool.py
+++ b/curvesim/pool/sim_interface/metapool.py
@@ -77,7 +77,7 @@ class SimCurveMetaPool(SimPool, AssetIndicesMixin, CurveMetaPool):
 
         for i in range(len(metapool_names)):
             self._metapool_names[i] = metapool_names[i]
-            
+
         for i in range(len(basepool_names)):
             self._basepool_names[i] = basepool_names[i]
 

--- a/curvesim/pool/sim_interface/pool.py
+++ b/curvesim/pool/sim_interface/pool.py
@@ -11,7 +11,7 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.asset_names(asset_names=self.coin_names)
+        self.asset_names = self.coin_names
 
         rates = self.rates  # pylint: disable=no-member
         for r in rates:
@@ -27,19 +27,20 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
 
     @asset_names.setter
     @override
-    def asset_names(self, **kwargs):
+    def asset_names(self, *asset_lists):
         """
         Set list of asset names.
         
-        Keywords:
+        Positional args:
 
-        asset_names: list of all pool asset names.
+        [0]: list of all pool asset names.
         """
-        asset_names = kwargs["asset_names"].copy()
+        asset_names = asset_lists[0].copy()
+
         if len(asset_names) != len(set(asset_names)):
             raise SimPoolError("SimPool must have unique asset names.")
 
-        if hasattr(self, "asset_names") and len(self.asset_names) != len(asset_names):
+        if hasattr(self, "_asset_names") and len(self.asset_names) != len(asset_names):
             raise SimPoolError("SimPool must have a consistent number of asset names.")
         
         self._asset_names = asset_names

--- a/curvesim/pool/sim_interface/pool.py
+++ b/curvesim/pool/sim_interface/pool.py
@@ -1,4 +1,4 @@
-from curvesim.exceptions import SimPoolError, CurvesimValueError
+from curvesim.exceptions import SimPoolError
 from curvesim.templates import SimAssets
 from curvesim.templates.sim_pool import SimPool
 from curvesim.utils import cache, override
@@ -11,7 +11,7 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.asset_names(self.coin_names.copy())
+        self.asset_names(asset_names=self.coin_names)
 
         rates = self.rates  # pylint: disable=no-member
         for r in rates:
@@ -27,16 +27,20 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
 
     @asset_names.setter
     @override
-    def asset_names(self, *asset_names):
-        """Set list of asset names."""
+    def asset_names(self, **kwargs):
+        """
+        Set list of asset names.
+        
+        Keywords:
+
+        asset_names: list of all pool asset names.
+        """
+        asset_names = kwargs["asset_names"].copy()
         if len(asset_names) != len(set(asset_names)):
             raise SimPoolError("SimPool must have unique asset names.")
 
         if hasattr(self, "asset_names") and len(self.asset_names) != len(asset_names):
             raise SimPoolError("SimPool must have a consistent number of asset names.")
-
-        # edge case: user specifies an arbitrary number of existing asset names, but with 
-        # at least one at a different index by mistake or as an attempt at switching coin indices
         
         self._asset_names = asset_names
 
@@ -73,4 +77,4 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
     @override
     @cache
     def assets(self):
-        return SimAssets(self.coin_names, self.coin_addresses, self.chain)
+        return SimAssets(self.asset_names, self.coin_addresses, self.chain)

--- a/curvesim/pool/sim_interface/pool.py
+++ b/curvesim/pool/sim_interface/pool.py
@@ -36,10 +36,6 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
 
         [0]: list of all pool asset names.
         """
-
-        # potential source of error: whenever asset_names is set, self._asset_names = ... gives it a reference to a 
-        # new array. objects like our SimAsset object below might contain the outdated reference, where the 
-        # "unused" outdated reference might get garbage collected - leaving some vital attributes as None or empty or whatever
         asset_names = asset_lists[0]
 
         if len(asset_names) != len(set(asset_names)):

--- a/curvesim/pool/sim_interface/pool.py
+++ b/curvesim/pool/sim_interface/pool.py
@@ -32,10 +32,15 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
         Set list of asset names.
 
         Positional args:
+        ----------------
 
         [0]: list of all pool asset names.
         """
-        asset_names = asset_lists[0].copy()
+
+        # potential source of error: whenever asset_names is set, self._asset_names = ... gives it a reference to a 
+        # new array. objects like our SimAsset object below might contain the outdated reference, where the 
+        # "unused" outdated reference might get garbage collected - leaving some vital attributes as None or empty or whatever
+        asset_names = asset_lists[0]
 
         if len(asset_names) != len(set(asset_names)):
             raise SimPoolError("SimPool must have unique asset names.")
@@ -43,7 +48,11 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
         if hasattr(self, "asset_names") and len(self.asset_names) != len(asset_names):
             raise SimPoolError("SimPool must have a consistent number of asset names.")
 
-        self._asset_names = asset_names
+        if not hasattr(self, "asset_names"):
+            self._asset_names = [str()] * len(asset_names)
+
+        for i in range(len(asset_names)):
+            self._asset_names[i] = asset_names[i]
 
     @property
     @override

--- a/curvesim/pool/sim_interface/pool.py
+++ b/curvesim/pool/sim_interface/pool.py
@@ -30,7 +30,7 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
     def asset_names(self, *asset_lists):
         """
         Set list of asset names.
-        
+
         Positional args:
 
         [0]: list of all pool asset names.
@@ -40,9 +40,9 @@ class SimCurvePool(SimPool, AssetIndicesMixin, CurvePool):
         if len(asset_names) != len(set(asset_names)):
             raise SimPoolError("SimPool must have unique asset names.")
 
-        if hasattr(self, "_asset_names") and len(self.asset_names) != len(asset_names):
+        if hasattr(self, "asset_names") and len(self.asset_names) != len(asset_names):
             raise SimPoolError("SimPool must have a consistent number of asset names.")
-        
+
         self._asset_names = asset_names
 
     @property

--- a/test/unit/test_coin_indices_mixin.py
+++ b/test/unit/test_coin_indices_mixin.py
@@ -66,9 +66,9 @@ def indices(sim_pool, *assets):
 
 def duplicates(sim_pool, *assets):
     """Determines whether assets contains duplicate symbols/indices"""
-    indices = indices(sim_pool, *assets)
+    asset_indices = indices(sim_pool, *assets)
 
-    return len(indices) != len(set(indices))
+    return len(asset_indices) != len(set(asset_indices))
 
 
 def test_asset_indices(sim_pool):
@@ -126,12 +126,17 @@ def test_get_asset_indices(sim_pool):
                 assert isinstance(err, CurvesimValueError)
 
 
-# test cases where asset_names and asset_balances are unequal length
-
-# setter
+# how we would test the asset_names setter
 # for breaking tests, check that the appropriate exception is raised (may need to use multiple functions in a
 # specific order to get the right error)
 
-# non-str input (e.g. ints that are and aren't duplicates of indices of the str)
-# change number of symbols after initial set
+# post-init set with duplicate symbols
+
 # initial set that's longer/shorter than _asset_balances
+# delete self.asset_names -> "initial" set immediately after
+
+# change number of symbols after initial set (no matter if valid length or invalid length)
+# assert isinstance(err, SimPoolError)
+
+# regular set to different symbols
+# check that get_asset_indices returns something different from before

--- a/test/unit/test_coin_indices_mixin.py
+++ b/test/unit/test_coin_indices_mixin.py
@@ -3,6 +3,7 @@ import pytest
 import itertools
 
 from curvesim.pool.sim_interface.asset_indices import AssetIndicesMixin
+from curvesim.exceptions import CurvesimValueError, SimPoolError
 from curvesim.utils import override
 
 # pylint: disable=redefined-outer-name
@@ -18,6 +19,19 @@ class FakeSimPool(AssetIndicesMixin):
     @override
     def asset_names(self):
         return ["SYM_0", "SYM_1", "SYM_2"]
+
+    @asset_names.setter
+    @override
+    def asset_names(self, *asset_lists):
+        asset_names = asset_lists[0].copy()
+
+        if len(asset_names) != len(set(asset_names)):
+            raise SimPoolError("SimPool must have unique asset names.")
+
+        if hasattr(self, "asset_names") and len(self.asset_names) != len(asset_names):
+            raise SimPoolError("SimPool must have a consistent number of asset names.")
+
+        self._asset_names = asset_names
 
     @property
     @override
@@ -67,10 +81,11 @@ def test_asset_indices(sim_pool):
 def test_asset_balances(sim_pool):
     assert sim_pool.asset_balances == {"SYM_0": 100, "SYM_1": 200, "SYM_2": 300}
 
+
 # make dedicated test function for get_asset_indices
 # convert test to test all permutations of mixed str and int inputs + duplicates (str/ str, int/int, str/int, int/str, etc.)
-    # on duplicate inputs assert that CurvesimValueError is thrown properly 
-        # CHECKS FOR STR/INT INPUT WILL BE DONE ELSEWHERE
+# on duplicate inputs assert that CurvesimValueError is thrown properly
+# CHECKS FOR STR/INT INPUT WILL BE DONE ELSEWHERE
 
 
 # test cases where asset_names and asset_balances are unequal length

--- a/test/unit/test_coin_indices_mixin.py
+++ b/test/unit/test_coin_indices_mixin.py
@@ -66,3 +66,11 @@ def test_asset_indices(sim_pool):
 
 def test_asset_balances(sim_pool):
     assert sim_pool.asset_balances == {"SYM_0": 100, "SYM_1": 200, "SYM_2": 300}
+
+# make dedicated test function for get_asset_indices
+# convert test to test all permutations of mixed str and int inputs + duplicates (str/ str, int/int, str/int, int/str, etc.)
+    # on duplicate inputs assert that CurvesimValueError is thrown properly 
+        # CHECKS FOR STR/INT INPUT WILL BE DONE ELSEWHERE
+
+
+# test cases where asset_names and asset_balances are unequal length


### PR DESCRIPTION
### Description
Resolves #172, resolves #187 

- `AssetIndicesMixin` children such as `SimCurvePool` and `SimCurveMetaPool` now have a convenient interface for setting the `AssetIndicesMixin.asset_names` attribute. Basic checks ensure that no duplicate names are set and that the number of asset names remains consistent after initialization. 
- In `AssetIndicesMixin.asset_balances`, the instance raises a `CurveSimException` if its `asset_names` and `_asset_balances` aren't the same length, ensuring that they will be.
- Expanded test coverage in `curvesim.test.unit.test_coin_indices_mixin`. Invalid data such as nonexistent asset indices or duplicate asset indices are passed to `AssetIndicesMixin.get_asset_indices()` to check the proper errors are raised.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [ ] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://twpark.com/wp-content/uploads/2022/10/Tanganyika_Alpaca_2021_CS2-683x1024.jpg)
