### PR TITLE
`CurveCryptoPool` maps to `SimCurveCryptoPool`

### DIFF
--- a/curvesim/pool_data/metadata/__init__.py
+++ b/curvesim/pool_data/metadata/__init__.py
@@ -4,7 +4,12 @@ __all__ = ["PoolMetaData", "PoolMetaDataInterface"]
 from curvesim.exceptions import CurvesimException
 from curvesim.network.subgraph import has_redemption_prices
 from curvesim.pool.cryptoswap import CurveCryptoPool
-from curvesim.pool.sim_interface import SimCurveMetaPool, SimCurvePool, SimCurveRaiPool
+from curvesim.pool.sim_interface import (
+    SimCurveMetaPool,
+    SimCurvePool,
+    SimCurveRaiPool,
+    SimCurveCryptoPool,
+)
 from curvesim.pool.stableswap import CurveMetaPool, CurvePool, CurveRaiPool
 from curvesim.pool_data.metadata.cryptoswap import CryptoswapMetaData
 
@@ -15,8 +20,7 @@ _SIM_POOL_TYPE = {
     CurvePool: SimCurvePool,
     CurveMetaPool: SimCurveMetaPool,
     CurveRaiPool: SimCurveRaiPool,
-    # TODO: create sim pool for crypto pools
-    CurveCryptoPool: None,
+    CurveCryptoPool: SimCurveCryptoPool,
 }
 
 _METADATA_TYPE = {

--- a/test/unit/test_pool_metadata.py
+++ b/test/unit/test_pool_metadata.py
@@ -1,8 +1,9 @@
 import json
 
-from curvesim.pool.cryptoswap.pool import CurveCryptoPool
+from curvesim.pool.sim_interface.cryptoswap import SimCurveCryptoPool
 from curvesim.pool.sim_interface.metapool import SimCurveMetaPool
 from curvesim.pool.sim_interface.pool import SimCurvePool
+from curvesim.pool.cryptoswap.pool import CurveCryptoPool
 from curvesim.pool.stableswap.metapool import CurveMetaPool
 from curvesim.pool.stableswap.pool import CurvePool
 from curvesim.pool_data.metadata import PoolMetaData
@@ -280,8 +281,7 @@ def test_cryptopool():
     assert metadata.chain == "mainnet"
 
     assert metadata.pool_type == CurveCryptoPool
-    # TODO: create sim pool for crypto pools
-    # assert metadata.sim_pool_type == SimCurveCryptoPool
+    assert metadata.sim_pool_type == SimCurveCryptoPool
 
     assert metadata.coin_names == ["STG", "USDC"]
     assert metadata.coins == [


### PR DESCRIPTION
### Description

Closes #191.

Make `SimCurveCryptoPool` the sim pool type corresponding to `CurveCryptoPool` in `curvesim.pool_data.metadata.__init__`.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/uQtojl282AZgtIkyRVvqnMCsyR43ZgMWCwDely_FdVg/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9lbW9q/aS5kaXNjYWRpYS5j/b20vZW1vamlzL2Qx/NjNkZjMwLTdiMDct/NDZjYy05NmVmLTQw/M2YzNjYzZDAwOC5q/cGc)
