### PR TITLE
Cryptopool price formula

### DIFF
--- a/changelog.d/20230809_125756_chanhosuh_crypto_price.rst
+++ b/changelog.d/20230809_125756_chanhosuh_crypto_price.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+- Added spot price methods `dydx` and `dydxfee` to the `CurveCryptoPool`.
+

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -1093,10 +1093,10 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         A_multiplier = 10**4
         gamma = self.gamma
 
-        K0 = n**n * prod(xp) / D**n
+        K0 = 10**18 * n**n * prod(xp) / D**n
 
-        coeff = gamma**2 * A / (D * (1 + gamma - K0) ** 2) / A_multiplier
-        frac = (1 + gamma + K0) / (1 + gamma - K0) * (sum(xp) - D)
+        coeff = gamma**2 * A / (D * (10**18 + gamma - K0) ** 2) / A_multiplier
+        frac = (10**18 + gamma + K0) * (sum(xp) - D) / (10**18 + gamma - K0)
         dydx = x_j * (1 + coeff * (x_i + frac)) / (x_i * (1 + coeff * (x_j + frac)))
 
         if j > 0:
@@ -1108,7 +1108,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
 
         if use_fee:
             fee = self._fee(xp)
-            dydx *= 1 - fee / 10**10
+            dydx = dydx - dydx * fee / 10**10
 
         return dydx
 

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -2,7 +2,7 @@
 Mainly a module to house the `CryptoPool`, a cryptoswap implementation in Python.
 """
 import time
-from math import isqrt
+from math import isqrt, prod
 from typing import List
 
 from curvesim.exceptions import CalculationError, CryptoPoolError
@@ -1028,6 +1028,86 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         d_token: int = token_supply * D // D0 - token_supply
         d_token -= self._calc_token_fee(amountsp, xp) * d_token // 10**10 + 1
         return d_token
+
+    def dydxfee(self, i, j):
+        """
+        Returns the spot price of i-th coin quoted in terms of j-th coin,
+        i.e. the ratio of output coin amount to input coin amount for
+        an "infinitesimally" small trade.
+
+        Trading fees are deducted.
+
+        Parameters
+        ----------
+        i: int
+            Index of coin to be priced; in a swapping context, this is
+            the "in"-token.
+        j: int
+            Index of quote currency; in a swapping context, this is the
+            "out"-token.
+
+        Returns
+        -------
+        float
+            Price of i-th coin quoted in j-th coin with fees deducted.
+
+        Note
+        ----
+        This is a "view" function; it doesn't change the state of the pool.
+        """
+        return self.dydx(i, j, use_fee=True)
+
+    def dydx(self, i, j, use_fee=False):
+        """
+        Returns the spot price of i-th coin quoted in terms of j-th coin,
+        i.e. the ratio of output coin amount to input coin amount for
+        an "infinitesimally" small trade.
+
+        Defaults to no fees deducted.
+
+        Parameters
+        ----------
+        i: int
+            Index of coin to be priced; in a swapping context, this is
+            the "in"-token.
+        j: int
+            Index of quote currency; in a swapping context, this is the
+            "out"-token.
+
+        Returns
+        -------
+        float
+            Price of i-th coin quoted in j-th coin
+
+        Note
+        ----
+        This is a "view" function; it doesn't change the state of the pool.
+        """
+        xp = self._xp()
+        x_i = xp[i]
+        x_j = xp[j]
+        n = len(xp)
+
+        D = self.D
+        A = self.A
+        A_multiplier = 10**4
+        gamma = self.gamma
+
+        K0 = n**n * prod(xp) / D**n
+
+        coeff = gamma**2 * A / (D * (1 + gamma - K0) ** 2) / A_multiplier
+        frac = (1 + gamma + K0) / (1 + gamma - K0) * (sum(xp) - D)
+        dydx = x_j * (1 + coeff * (x_i + frac)) / (x_i * (1 + coeff * (x_j + frac)))
+
+        if j > 0:
+            price_scale = self.price_scale[j - 1]
+            dydx = dydx * 10**18 / price_scale
+        else:
+            # TODO: handle other case
+            ...
+
+        # TODO: add fee
+        return dydx
 
 
 def _get_unix_timestamp():

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -1102,9 +1102,9 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         if j > 0:
             price_scale = self.price_scale[j - 1]
             dydx = dydx * 10**18 / price_scale
-        else:
-            # TODO: handle other case
-            ...
+        if i > 0:
+            price_scale = self.price_scale[i - 1]
+            dydx = dydx * price_scale / 10**18
 
         if use_fee:
             fee = self._fee(xp)

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -1106,7 +1106,10 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             # TODO: handle other case
             ...
 
-        # TODO: add fee
+        if use_fee:
+            fee = self._fee(xp)
+            dydx *= 1 - fee / 10**10
+
         return dydx
 
 

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -772,4 +772,4 @@ def test_dydxfee(vyper_cryptopool):
 
     dx *= precisions[i]
     dy *= precisions[j]
-    assert dydx == dy / dx
+    assert abs(dydx - dy / dx) < 5e-3

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -761,11 +761,9 @@ def test_dydxfee(vyper_cryptopool):
     pool = initialize_pool(vyper_cryptopool)
     i = 0
     j = 1
-    dydx = pool.dydx(i, j)
+    dydx = pool.dydxfee(i, j)
     dx = 10**14
     dy = vyper_cryptopool.exchange(i, j, dx, 0)
     dy *= 10**12
-
-    print(pool.price_scale)
 
     assert dydx == dy / dx

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -758,6 +758,7 @@ def test_multiple_exchange_with_repeg(
 
 
 def test_dydxfee(vyper_cryptopool):
+    """Test spot price formula against execution price for small trades."""
     pool = initialize_pool(vyper_cryptopool)
 
     # STG, USDC

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -766,10 +766,11 @@ def test_dydxfee(vyper_cryptopool):
 
     i = 0
     j = 1
+    dx = 10**18
+
     dydx = pool.dydxfee(i, j)
-    dx = 10**14
     dy = vyper_cryptopool.exchange(i, j, dx, 0)
 
     dx *= precisions[i]
     dy *= precisions[j]
-    assert abs(dydx - dy / dx) < 5e-3
+    assert abs(dydx - dy / dx) < 1e-6

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -759,11 +759,17 @@ def test_multiple_exchange_with_repeg(
 
 def test_dydxfee(vyper_cryptopool):
     pool = initialize_pool(vyper_cryptopool)
+
+    # STG, USDC
+    decimals = [18, 6]
+    precisions = [10 ** (18 - d) for d in decimals]
+
     i = 0
     j = 1
     dydx = pool.dydxfee(i, j)
     dx = 10**14
     dy = vyper_cryptopool.exchange(i, j, dx, 0)
-    dy *= 10**12
 
+    dx *= precisions[i]
+    dy *= precisions[j]
     assert dydx == dy / dx

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -755,3 +755,17 @@ def test_multiple_exchange_with_repeg(
         assert pool.price_scale == expected_price_scale
 
         boa.env.time_travel(time_delta)
+
+
+def test_dydxfee(vyper_cryptopool):
+    pool = initialize_pool(vyper_cryptopool)
+    i = 0
+    j = 1
+    dydx = pool.dydx(i, j)
+    dx = 10**14
+    dy = vyper_cryptopool.exchange(i, j, dx, 0)
+    dy *= 10**12
+
+    print(pool.price_scale)
+
+    assert dydx == dy / dx

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -419,3 +419,44 @@ def test__newton_y(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     y = _newton_y(A, gamma, xp, D, j)
 
     assert y == expected_y
+
+
+def test_dydxfee(vyper_tricrypto):
+    pool = initialize_pool(vyper_tricrypto)
+
+    # USDT, WBTC, WETH
+    decimals = [6, 8, 18]
+    precisions = [10 ** (18 - d) for d in decimals]
+
+    i = 0
+    j = 1
+    dydx = pool.dydxfee(i, j)
+    dx = 10**6
+    dy = vyper_tricrypto.exchange(i, j, dx, 0)
+    pool.exchange(i, j, dx, 0)
+
+    dx *= precisions[i]
+    dy *= precisions[j]
+    # assert dydx == dy / dx
+
+    i = 1
+    j = 0
+    dydx = pool.dydxfee(i, j)
+    dx = 10**8
+    dy = vyper_tricrypto.exchange(i, j, dx, 0)
+    pool.exchange(i, j, dx, 0)
+
+    dx *= precisions[i]
+    dy *= precisions[j]
+    # assert dydx == dy / dx
+
+    i = 2
+    j = 1
+    dydx = pool.dydxfee(i, j)
+    dx = 10**18
+    dy = vyper_tricrypto.exchange(i, j, dx, 0)
+    pool.exchange(i, j, dx, 0)
+
+    dx *= precisions[i]
+    dy *= precisions[j]
+    assert dydx == dy / dx

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -428,6 +428,9 @@ def test_dydxfee(vyper_tricrypto):
     decimals = [6, 8, 18]
     precisions = [10 ** (18 - d) for d in decimals]
 
+    print("WBTC price:", pool.price_scale[0] / 10**18)
+    print("WETH price:", pool.price_scale[1] / 10**18)
+
     i = 0
     j = 1
     dydx = pool.dydxfee(i, j)
@@ -437,18 +440,18 @@ def test_dydxfee(vyper_tricrypto):
 
     dx *= precisions[i]
     dy *= precisions[j]
-    assert abs(dydx - dy / dx) < 1e-3
+    assert abs(dydx - dy / dx) < 1e-4
 
     i = 1
     j = 0
     dydx = pool.dydxfee(i, j)
-    dx = 10**8
+    dx = 10**2
     dy = vyper_tricrypto.exchange(i, j, dx, 0)
     pool.exchange(i, j, dx, 0)
 
     dx *= precisions[i]
     dy *= precisions[j]
-    assert abs(dydx - dy / dx) < 100
+    assert abs(dydx - dy / dx) < 1
 
     i = 2
     j = 1
@@ -459,4 +462,4 @@ def test_dydxfee(vyper_tricrypto):
 
     dx *= precisions[i]
     dy *= precisions[j]
-    assert abs(dydx - dy / dx) < 1e-3
+    assert abs(dydx - dy / dx) < 1e-5

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -437,7 +437,7 @@ def test_dydxfee(vyper_tricrypto):
 
     dx *= precisions[i]
     dy *= precisions[j]
-    # assert dydx == dy / dx
+    assert abs(dydx - dy / dx) < 1e-3
 
     i = 1
     j = 0
@@ -448,7 +448,7 @@ def test_dydxfee(vyper_tricrypto):
 
     dx *= precisions[i]
     dy *= precisions[j]
-    # assert dydx == dy / dx
+    assert abs(dydx - dy / dx) < 100
 
     i = 2
     j = 1
@@ -459,4 +459,4 @@ def test_dydxfee(vyper_tricrypto):
 
     dx *= precisions[i]
     dy *= precisions[j]
-    assert dydx == dy / dx
+    assert abs(dydx - dy / dx) < 1e-3

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -423,6 +423,7 @@ def test__newton_y(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
 
 
 def test_dydxfee(vyper_tricrypto):
+    """Test spot price formula against execution price for small trades."""
     pool = initialize_pool(vyper_tricrypto)
 
     # USDT, WBTC, WETH


### PR DESCRIPTION
### Description

Created methods `dydxfee` and `dydx` for the `CurveCryptoPool`.  These are analogous to the same named methods on the other Curve pool classes, i.e. compute spot sprice for a coin pair with and without fee.

Some sanity checking has been done against both 2 and 3-coin vyper fixtures to see the values are reasonable and automated as basic unit tests.  Another PR should continue the work of testing more thoroughly against a range of pool balances and parameters.

Closes #178.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Pylint score monotonically increased
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://us.123rf.com/450wm/shanemyersphoto/shanemyersphoto1712/shanemyersphoto171200217/97922232-hawaiian-green-sea-turtle-cruising-in-the-warm-waters-of-the-pacific-ocean-in-hawaii.jpg?ver=6)
