### PR TITLE
Add prepare_for_run to SimPools

### DIFF
--- a/changelog.d/20230816_112532_nagakingg_prepare-for-run.rst
+++ b/changelog.d/20230816_112532_nagakingg_prepare-for-run.rst
@@ -1,0 +1,3 @@
+Added
+-----
+- Add prepare_for_run method to SimPools

--- a/curvesim/templates/sim_pool.py
+++ b/curvesim/templates/sim_pool.py
@@ -27,6 +27,18 @@ class SimPool(ABC):
             the time to sample from
         """
 
+    def prepare_for_run(self, prices):
+        """
+        Does any necessary preparation before beginning a simulation run.
+
+        Base implementation is a no-op.
+
+        Parameters
+        ----------
+        timestamp : pandas.DataFrame
+            The price time_series, price_sampler.prices.
+        """
+
     @abstractmethod
     def price(self, coin_in, coin_out, use_fee=True):
         """

--- a/curvesim/templates/strategy.py
+++ b/curvesim/templates/strategy.py
@@ -65,8 +65,9 @@ class Strategy(ABC):
         trader = self.trader_class(pool)
         state_log = self.state_log_class(pool, self.metrics)
 
-        symbol = pool.symbol
-        logger.info("[%s] Simulating with %s", symbol, parameters)
+        logger.info("[%s] Simulating with %s", pool.symbol, parameters)
+
+        pool.prepare_for_run(price_sampler.prices)
 
         for sample in price_sampler:
             pool.prepare_for_trades(sample.timestamp)

--- a/test/fixtures/sim_pools.py
+++ b/test/fixtures/sim_pools.py
@@ -67,3 +67,31 @@ def sim_curve_crypto_pool():
     }
 
     return SimCurveCryptoPool(**kwargs)
+
+
+@pytest.fixture(scope="function")
+def sim_curve_tricrypto_pool():
+    kwargs = {
+        "A": 1707629,
+        "gamma": 11809167828997,
+        "n": 3,
+        "precisions": [1, 1, 1],
+        "mid_fee": 3000000,
+        "out_fee": 30000000,
+        "allowed_extra_profit": 2000000000000,
+        "fee_gamma": 500000000000000,
+        "adjustment_step": 490000000000000,
+        "admin_fee": 5000000000,
+        "ma_half_time": 865,
+        "price_scale": [30453123431671769818574, 1871140849377954208512],
+        "balances": [
+            18418434882428000000000000,
+            605473277480000000000,
+            9914993293693631287774,
+        ],
+        "tokens": 47986553926751950746367,
+        "xcp_profit": 1000448625854298803,
+        "xcp_profit_a": 1000440033249679801,
+    }
+
+    return SimCurveCryptoPool(**kwargs)

--- a/test/simple_ci.py
+++ b/test/simple_ci.py
@@ -116,7 +116,6 @@ def per_trade(sim, stored, threshold=0.9):
     print("Testing per-trade data...")
 
     # Compare metric columns
-    stored = stored.drop(columns=["liquidity_density"])
     compare_metrics(sim.columns, stored.columns)
     sim = sim[stored.columns]
 
@@ -155,9 +154,6 @@ def summary(sim, stored, threshold=0.99):
     print("Testing summary data...")
 
     # Compare metric columns
-    stored = stored.drop(
-        columns=[("liquidity_density", "median"), ("liquidity_density", "min")]
-    )
     compare_metrics(sim.columns, stored.columns)
     sim = sim[stored.columns]
 

--- a/test/unit/test_prepare_for_run.py
+++ b/test/unit/test_prepare_for_run.py
@@ -1,0 +1,112 @@
+"""Unit tests for SimPool .prepare_for_run method."""
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pandas import DataFrame
+
+
+def test_cryptoswap2_prepare_for_run_same_price(sim_curve_crypto_pool):
+    """Test SimCurveCryptoPool.prepare_for_run with 2-coin pool, no price changes"""
+    _test_cryptoswap_prepare_for_run_same_price(sim_curve_crypto_pool)
+
+
+def test_cryptoswap3_prepare_for_run_same_price(sim_curve_tricrypto_pool):
+    """Test SimCurveCryptoPool.prepare_for_run with 3-coin pool, no price changes"""
+    _test_cryptoswap_prepare_for_run_same_price(sim_curve_tricrypto_pool)
+
+
+@given(st.floats(min_value=0.1, max_value=0.9))
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_cryptoswap2_prepare_for_run_low_price(sim_curve_crypto_pool, scalar):
+    """Test SimCurveCryptoPool.prepare_for_run with 2-coin pool, lower prices"""
+    _test_cryptoswap_prepare_for_run(sim_curve_crypto_pool, scalar)
+
+
+@given(st.floats(min_value=0.1, max_value=0.9))
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_cryptoswap3_prepare_for_run_low_price(sim_curve_tricrypto_pool, scalar):
+    """Test SimCurveCryptoPool.prepare_for_run with 3-coin pool, lower prices"""
+    _test_cryptoswap_prepare_for_run(sim_curve_tricrypto_pool, scalar)
+
+
+@given(st.floats(min_value=1.1, max_value=10))
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_cryptoswap2_prepare_for_run_high_price(sim_curve_crypto_pool, scalar):
+    """Test SimCurveCryptoPool.prepare_for_run with 2-coin pool, higher prices"""
+    _test_cryptoswap_prepare_for_run(sim_curve_crypto_pool, scalar)
+
+
+@given(st.floats(min_value=1.1, max_value=10))
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_cryptoswap3_prepare_for_run_high_price(sim_curve_tricrypto_pool, scalar):
+    """Test SimCurveCryptoPool.prepare_for_run with 3-coin pool, higher prices"""
+    _test_cryptoswap_prepare_for_run(sim_curve_tricrypto_pool, scalar)
+
+
+def _test_cryptoswap_prepare_for_run_same_price(pool):
+    """Test that preserving price_scale doesn't change D or xcp(D)"""
+
+    original_D = pool.D
+    original_xcp = pool._get_xcp(pool.D)
+    original_price_scale = pool.price_scale
+
+    prices = [10**18 / p for p in pool.price_scale]
+    prices = DataFrame([prices, prices])
+
+    pool.prepare_for_run(prices)
+
+    # Test that price attributes updated correctly
+    _test_list_equality(pool.price_scale, original_price_scale)
+    _test_list_equality(pool._price_oracle, original_price_scale)
+    _test_list_equality(pool.last_prices, original_price_scale)
+
+    # Test that D/xcp didn't change
+    new_xcp = pool._get_xcp(pool.D)
+
+    assert abs(pool.D - original_D) < 10**10
+    assert abs(new_xcp - original_xcp) < 10**10
+
+
+def _test_cryptoswap_prepare_for_run(pool, scalar):
+    """Test that changing price_scale doesn't change xcp(D), but changes D"""
+
+    original_D = pool.D
+    original_xcp = pool._get_xcp(pool.D)
+    new_price_scale = [int(p * scalar) for p in pool.price_scale]
+
+    prices = [10**18 / p for p in new_price_scale]
+    prices = DataFrame([prices, prices])
+
+    pool.prepare_for_run(prices)
+
+    # Test that price attributes updated correctly
+    _test_list_equality(pool.price_scale, new_price_scale)
+    _test_list_equality(pool._price_oracle, new_price_scale)
+    _test_list_equality(pool.last_prices, new_price_scale)
+
+    # Test that xcp didn't change but D did
+    new_xcp = pool._get_xcp(pool.D)
+
+    assert abs(pool.D - original_D) > 10**10
+    assert abs(new_xcp - original_xcp) < 10**10
+
+
+def _test_list_equality(list1, list2, tol=10**10):
+    """Test that differences are < tol for all elements"""
+    assert all([abs(val1 - val2) < tol for val1, val2 in zip(list1, list2)])


### PR DESCRIPTION
### Description

- Add prepare_for_run method to SimPool template
- Call prepare_for_run before running sim in strategy template
- Add prepare_for_run to SimCurveCryptoPool

SimCurveCryptoPool.prepare_for_run updates price_scale, _price_oracle, and last_prices to the first price of the price time-series. Balances are then adjusted to balance the pool's holdings while preserving xcp(D).

ToDo:
- test SimCurveCryptoPool.prepare_for_run
- recompute test data for v2 pools


### Hygiene checklist

- [ ] Changelog entry
- [ ] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [ ] Pylint score monotonically increased
- [ ] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
