### PR TITLE
Test `CurveCryptoPool` spot price

### DIFF
--- a/test/fixtures/pool.py
+++ b/test/fixtures/pool.py
@@ -1,6 +1,7 @@
 """Pool fixtures to test against vyper implementation.  Uses titanoboa."""
 # pylint: disable=redefined-outer-name
 import os
+from time import time
 
 import boa
 import pytest
@@ -276,6 +277,7 @@ def _vyper_tricrypto():
     _weth = FAKE_ADDRESS
     _math = boa.load(tricrypto_math_filepath)
 
+    tricrypto_start = time()
     tricrypto = boa.load(
         trycrypto_ng_filepath,
         _name,
@@ -290,6 +292,9 @@ def _vyper_tricrypto():
         packed_rebalancing_params,
         packed_prices,
     )
+    tricrypto_end = time()
+    test_point = f"boa.load (_vyper_tricrypto): {tricrypto_end - tricrypto_start} s"
+    print(test_point)
     """
     name :
     TricryptoUSDT

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -630,7 +630,7 @@ def test_dydxfee(vyper_tricrypto):
         HealthCheck.function_scoped_fixture,
         HealthCheck.filter_too_much,
     ],
-    max_examples=25,
+    max_examples=2,
     deadline=None,
     phases=(
         Phase.reuse,
@@ -655,13 +655,6 @@ def test_dydxfee_boa(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
 
     vyper_tricrypto = override_initialization(vyper_tricrypto, A, gamma, xp)
     pool = initialize_pool(vyper_tricrypto)
-
-    # dxs = [
-    #     10**6,
-    #     10**4,
-    #     10**15,
-    # ]
-    # dx = dxs[i]
 
     # D_UNIT precision to mitigate floating point arithmetic error
     dydx = pool.dydxfee(i, j) * D_UNIT
@@ -693,7 +686,7 @@ def test_dydxfee_boa(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
         HealthCheck.function_scoped_fixture,
         HealthCheck.filter_too_much,
     ],
-    max_examples=25,
+    max_examples=2,
     deadline=None,
     phases=(
         Phase.reuse,
@@ -718,13 +711,6 @@ def test_dydxfee_python(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
 
     pool = override_initialization_python(vyper_tricrypto, A, gamma, xp)
 
-    # dxs = [
-    #     10**6,
-    #     10**4,
-    #     10**15,
-    # ]
-    # dx = dxs[i]
-
     # D_UNIT precision to mitigate floating point arithmetic error
     dydx = pool.dydxfee(i, j) * D_UNIT
     dx = xp[i] * dx_perc // 10000  # basis points increase
@@ -738,21 +724,4 @@ def test_dydxfee_python(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
         < (dx_perc + 5) * D_UNIT // 10000
     )
 
-# things to time:
-# boa load of vyper fixture
-# overriding vyper fixture attributes
-# initialize_pool(vyper_tricrypto)
 
-# override_initialization_python(vyper_tricrypto)
-
-
-# Plan for more thorough testing of dydxfee:
-# other params:
-# num. of times to do trades?
-
-# use our dy solver's solution as the reference point for error
-# in future, differentiate polynomial interpolated bonding curve
-# (using a set of points on the curve, e.g. Chebyshev nodes)
-# Newton interpolation or Barycentric form of Langrage interpolation
-# at every point used for interpolation, assert abs. error of spot_price(point) < maximum error
-# maximum error is based on trade size (or perhaps constant)

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -569,7 +569,7 @@ def test_dydxfee_2(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     # ]
     # dx = dxs[i]
 
-    # D_UNIT precision to mitigate floating point numeric instability
+    # D_UNIT precision to mitigate floating point arithmetic error
     dydx = pool.dydxfee(i, j) * D_UNIT
     dx = xp[i] * dx_perc // 10000  # basis points increase
     dy = pool.exchange(i, j, dx, 0)[0]

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -185,7 +185,8 @@ def update_cached_values(vyper_tricrypto):
     )
 
     update_cached_end = time()
-    test_point = f"update_cached_values - get_math: {(update_cached_end - update_cached_start) - get_math_time} s"
+    test_point = f"update_cached_values - get_math: \
+        {(update_cached_end - update_cached_start) - get_math_time} s"
     print(test_point)
 
 
@@ -256,7 +257,7 @@ def override_initialization(vyper_tricrypto, A, gamma, balances):
 def override_initialization_python(vyper_tricrypto, A, gamma, balances):
     """
     Helper that overrides the attributes of a CurveCryptoPool
-    initialized from the vyper_tricrypto fixture. 
+    initialized from the vyper_tricrypto fixture.
     End result emulates a balanced, newly
     created pool with 0 profit or loss.
     """
@@ -723,5 +724,3 @@ def test_dydxfee_python(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
         abs(dydx - discretized) * D_UNIT // discretized
         < (dx_perc + 5) * D_UNIT // 10000
     )
-
-

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -558,8 +558,9 @@ def test_dydxfee_2(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     #     10**4,
     #     10**15,
     # ]
-    #dx = dxs[i]
+    # dx = dxs[i]
 
+    # D_UNIT precision to mitigate floating point numeric instability
     dydx = pool.dydxfee(i, j) * D_UNIT
     dx = xp[i] * dx_perc // 10000 # basis points increase
     dy = pool.exchange(i, j, dx, 0)[0]
@@ -570,15 +571,12 @@ def test_dydxfee_2(vyper_tricrypto, A, gamma, x0, x1, x2, pair, dx_perc):
     assert abs(dydx - discretized) * D_UNIT // discretized < (dx_perc + 5) * D_UNIT // 10000
 
 
-# other params
+# Plan for more thorough testing of dydxfee:
+# other params:
 # num. of times to do trades?
 
-# use our solvers' solutions for D, y, etc. as the reference point for error
-# each time, record error from discretized derivative for now (simple abs difference for now)
-# in future, differentiate newton interpolated bonding curve (using a set of points on the curve) 
-# at start and end points and take abs. difference from spot formula
-# even more advanced: integrate abs(polynomial - spot) dx_i over [(before trade), (after trade)] or [(after trade), (before trade)]
-# (we are interested in error over the trade range, not just at a point)
-# at every point used for interpolation, assert abs. error of f(point) < maximum
-
-# just assert the same accuracy every time no matter what
+# use our dy solver's solution as the reference point for error
+# in future, differentiate polynomial interpolated bonding curve (using a set of points on the curve, e.g. Chebyshev nodes)
+# Newton interpolation or Barycentric form of Langrage interpolation
+# at every point used for interpolation, assert abs. error of spot_price(point) < maximum error
+# maximum error is based on trade size (or perhaps constant)


### PR DESCRIPTION
### Description

Added a test asserting the lower bound of `CurveCryptoPool.dydxfee` relative to actual trade prices calculated by `CurveCryptoPool.exchange`. Also added timers to record speed of select functions in `test.unit.test_tricrypto` and the `vyper_tricrypto`fixture in `test.fixture.pool`. Operations being timed include: `boa.load`, `boa.load_partial`, evaluating vyper statements through boa, and overriding `CurveCryptoPool` attributes. 


### Hygiene checklist

- [ ] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/z0lbocox5sor5UdOjJeUZRPwFFmJIQBj6yVBVQxrVO4/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9pLnBp/bmltZy5jb20vb3Jp/Z2luYWxzLzYyLzhi/LzU5LzYyOGI1OWM2/MzE2ODBhODRlY2Yw/ZmViZTg4YTQ5MDAy/LS1uZXdib3Jucy1u/ZXdib3JuLWJhYmll/cy5qcGc)
