### PR TITLE
Fix deprecations

### DIFF
--- a/changelog.d/20230824_175938_philiplu97_fix_deprecations.rst
+++ b/changelog.d/20230824_175938_philiplu97_fix_deprecations.rst
@@ -1,0 +1,37 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+Added
+-----
+
+- Utils now has get_event_loop to access the event loop, which deprecates asyncio.get_event_loop.
+
+Changed
+-------
+
+- In curvesim.network.nomics, curvesim.network.utils, and curvesim.pool_data.queries, all instances of
+  asyncio.get_event_loop were replaced with get_event_loop imported from curvesim.utils.
+
+- Updated deprecated license_file parameter to license_files in setup.cfg.
+
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/curvesim/network/nomics.py
+++ b/curvesim/network/nomics.py
@@ -10,7 +10,7 @@ import pandas as pd
 from numpy import NaN
 
 from curvesim.logging import get_logger
-from curvesim.utils import get_env_var
+from curvesim.utils import get_env_var, get_event_loop
 
 from .http import HTTP
 from .utils import sync
@@ -178,7 +178,7 @@ def update(
     t_start_orig = t_start
     t_end = t_end.replace(tzinfo=timezone.utc)
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     coins = coin_ids_from_addresses_sync(coins, event_loop=loop)
 
     # Coins priced against one another
@@ -279,7 +279,7 @@ def pool_prices(  # noqa: C901
     pzero : pandas.Series
         Proportion of timestamps with zero volume.
     """
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
 
     coins = coins or []
     pairs = pairs or []

--- a/curvesim/network/utils.py
+++ b/curvesim/network/utils.py
@@ -5,6 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 from gmpy2 import mpz
 
+from curvesim.utils import get_event_loop
+
 
 def compute_D(xp, A):
     """Standalone `D` calc neede for some data processing."""
@@ -59,7 +61,7 @@ def sync(func):
 
     @functools.wraps(func)
     def inner(*args, event_loop=None, **kwargs):
-        loop = event_loop or asyncio.get_event_loop()
+        loop = event_loop or get_event_loop()
         coro = func(*args, **kwargs)
         if loop.is_running():
             # If for some reason, we are trying to make async code

--- a/curvesim/pool_data/queries.py
+++ b/curvesim/pool_data/queries.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from curvesim.utils import get_event_loop
 
 from ..network.subgraph import pool_snapshot_sync, symbol_address_sync

--- a/curvesim/pool_data/queries.py
+++ b/curvesim/pool_data/queries.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from curvesim.utils import get_event_loop
+
 from ..network.subgraph import pool_snapshot_sync, symbol_address_sync
 from ..network.web3 import underlying_coin_info_sync
 
@@ -22,7 +24,7 @@ def from_address(address, chain, env="prod", end_ts=None):
     Pool snapshot dictionary in the format returned by
     :func:`curvesim.network.subgraph.pool_snapshot`.
     """
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     data = pool_snapshot_sync(address, chain, env=env, end_ts=end_ts, event_loop=loop)
 
     # Get underlying token addresses

--- a/curvesim/utils.py
+++ b/curvesim/utils.py
@@ -172,7 +172,7 @@ def get_event_loop():
     https://docs.python.org/3.11/library/asyncio-eventloop.html?highlight=selectoreventloop#asyncio.get_event_loop.
 
     Implementation slightly modified from https://stackoverflow.com/a/73884759
-    as supporting all Python 3.x isn't necessary.
+    as below works for all versions >= 3.7.
     """
     try:
         loop = asyncio.get_running_loop()

--- a/curvesim/utils.py
+++ b/curvesim/utils.py
@@ -1,6 +1,7 @@
 """Utlity functions for general usage in Curvesim."""
 import functools
 import inspect
+import asyncio
 import os
 import re
 import sys
@@ -156,3 +157,21 @@ def dataclass(*args, **kwargs):
         del kwargs["slots"]
 
     return _dataclass(*args, **kwargs)
+
+
+def get_event_loop():
+    """
+    reasoning, stackoverflow post
+    default asyncio.get_event_loop() will simply emit a DeprecationWarning 
+    if there is no event loop set or running This will become an error in future releases
+
+    Generally, after calling this, you should run scheduled coroutines soon after 
+    to avoid overwriting event loops that have unrun coroutines.
+    """
+    try: 
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    return loop

--- a/curvesim/utils.py
+++ b/curvesim/utils.py
@@ -1,7 +1,7 @@
 """Utlity functions for general usage in Curvesim."""
+import asyncio
 import functools
 import inspect
-import asyncio
 import os
 import re
 import sys
@@ -161,14 +161,20 @@ def dataclass(*args, **kwargs):
 
 def get_event_loop():
     """
-    reasoning, stackoverflow post
-    default asyncio.get_event_loop() will simply emit a DeprecationWarning 
-    if there is no event loop set or running This will become an error in future releases
+    Access the event loop without using asyncio.get_event_loop().
 
-    Generally, after calling this, you should run scheduled coroutines soon after 
-    to avoid overwriting event loops that have unrun coroutines.
+    Generally, you should run scheduled coroutines soon after calling
+    this to avoid overwriting event loops that have unrun coroutines.
+
+    Calling asyncio.get_event_loop() when an event loop isn't running and/or
+    set will cause a DeprecationWarning in various versions of Python 3.10-3.12,
+    and a future release will start raising an error instead:
+    https://docs.python.org/3.11/library/asyncio-eventloop.html?highlight=selectoreventloop#asyncio.get_event_loop.
+
+    Implementation slightly modified from https://stackoverflow.com/a/73884759
+    as supporting all Python 3.x isn't necessary.
     """
-    try: 
+    try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ url = https://github.com/curveresearch/curvesim
 author = Curve Research
 author_email = help@curveresearch.org
 license = MIT
-license_file = LICENSE.md
+license_files = LICENSE.md
 classifiers = 
 	Development Status :: 4 - Beta
 	Environment :: Console


### PR DESCRIPTION
### Description

- Added `get_event_loop` to `curvesim.utils`, replacing usage of `asyncio.get_event_loop` across various files, to avoid DeprecationWarning (which will become an error in the future) raised when you call `asyncio.get_event_loop` without a running/set event loop.
- Replaced deprecated `license_file` `setup.cfg` param with `license_files`.

Resolves #160, resolves #157.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/bEdAFXHTIraNjfsMnQjuiLkzo6wUyoqE4eHlEyeO3-Q/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9pLnBp/bmltZy5jb20vb3Jp/Z2luYWxzL2M5Lzkx/Lzg5L2M5OTE4OWQy/NWVjOWI1OWEzNThk/ZWM5YzRhYzk0NTgy/LS1kb3ZlcnMtYmFi/eS1sYW1iLmpwZw)
