### PR TITLE
Remove subgraph stopgaps

### DIFF
--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -107,7 +107,7 @@ class ArbMetrics(PricingMetric):
 
         return results
 
-    def _compute_profits(self, price_df, trade_df):
+    def _compute_profits(self, price_df, trade_df):  # pylint: disable=too-many-locals
         """
         Computes arbitrageur profits and pool fees for a single row of data (i.e.,
         a single timestamp) in units of the chosen numeraire, `self.numeraire`.

--- a/curvesim/pool_data/metadata/cryptoswap.py
+++ b/curvesim/pool_data/metadata/cryptoswap.py
@@ -43,35 +43,6 @@ class CryptoswapMetaData(PoolMetaDataBase):
                 coin_balances = data["reserves"]["unnormalized_by_coin"]
             kwargs["balances"] = coin_balances
 
-        # Aug 15, 2023
-        #
-        # This is fallback logic for missing subgraph functionality.  Right now
-        # the subgraph will return 0 for crypto pools with more than 2 coins.
-        # ETA for fix is expected to be within few weeks.
-        #
-        # Using the staging subgraph should suffice for tricrypto-ng factory pools.
-        if n == 3:
-            if len(kwargs["price_scale"]) != 2:
-                logger.warning("Price scale is missing.  Using ad-hoc setting.")
-                coin_balances = data["reserves"]["by_coin"]
-                numeraire_balance = coin_balances[0]
-                price_scale = [
-                    numeraire_balance * 10**18 // coin_balances[1],
-                    numeraire_balance * 10**18 // coin_balances[2],
-                ]
-                kwargs["price_scale"] = price_scale
-
-                A = kwargs["A"]
-                gamma = kwargs["gamma"]
-                xp = [
-                    coin_balances[0],
-                    coin_balances[0],
-                    coin_balances[0],
-                ]
-
-                D = newton_D(A, gamma, xp)
-                kwargs["D"] = D
-
         # Due to outstanding subgraph bug, we need to do something for
         # the missing value.
         if not kwargs["ma_half_time"]:

--- a/curvesim/pool_data/metadata/cryptoswap.py
+++ b/curvesim/pool_data/metadata/cryptoswap.py
@@ -1,5 +1,4 @@
 from curvesim.logging import get_logger
-from curvesim.pool.cryptoswap.calcs import newton_D
 
 from .base import PoolMetaDataBase
 

--- a/curvesim/pool_data/metadata/cryptoswap.py
+++ b/curvesim/pool_data/metadata/cryptoswap.py
@@ -43,11 +43,6 @@ class CryptoswapMetaData(PoolMetaDataBase):
                 coin_balances = data["reserves"]["unnormalized_by_coin"]
             kwargs["balances"] = coin_balances
 
-        # Due to outstanding subgraph bug, we need to do something for
-        # the missing value.
-        if not kwargs["ma_half_time"]:
-            kwargs["ma_half_time"] = 600
-
         return kwargs
 
     @property

--- a/test/ci.py
+++ b/test/ci.py
@@ -56,7 +56,7 @@ def main(generate=False, ncpu=None):
         {
             "address": "0x4ebdf703948ddcea3b11f675b4d1fba9d2414a14",
             "end_timestamp": 1692215156,
-            "env": "staging",
+            # "env": "staging",
         },
     ]
 

--- a/test/simple_ci.py
+++ b/test/simple_ci.py
@@ -32,7 +32,7 @@ pools = [
     {
         "address": "0x4ebdf703948ddcea3b11f675b4d1fba9d2414a14",
         "end_timestamp": 1692215156,
-        "env": "staging",
+        # "env": "staging",
     },
 ]
 


### PR DESCRIPTION
### Description

Removed subgraph stopgaps for cryptopool values:

- missing `ma_half_time`
- missing `price_scale`

Removed use of `staging` environment for tests.

### Hygiene checklist

- [ ] <s>Changelog entry</s>
- [ ] <s>Everything public has a Numpy-style docstring</s>
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1155030342/photo/dog-travel-by-car.jpg?s=612x612&w=0&k=20&c=dZ3JIKzExiEGUWoULEEmrst_WUcFPAnbTY9fnPuszoM=)
