### PR TITLE
Crypto pool init fixes

### DIFF
--- a/changelog.d/20230907_180216_chanhosuh_crypto_init_fix.rst
+++ b/changelog.d/20230907_180216_chanhosuh_crypto_init_fix.rst
@@ -1,0 +1,10 @@
+Added
+-----
+
+- `virtual_price` is an allowed optional argument for pools.
+
+Fixed
+-----
+
+- Pool creation would fail if no `tokens` argument was provided to `CurveCryptoPool`.
+- Wrong `D` value was computed for 3-coin `CurveCryptoPool`.

--- a/curvesim/network/subgraph.py
+++ b/curvesim/network/subgraph.py
@@ -318,6 +318,7 @@ async def _pool_snapshot(address, chain, env, end_ts=None):
     return r
 
 
+# pylint: disable-next=too-many-locals
 async def pool_snapshot(address, chain, env="prod", end_ts=None):
     """
     Async function to pull pool state and metadata from daily snapshots.

--- a/curvesim/pool/cryptoswap/calcs/factory_2_coin.py
+++ b/curvesim/pool/cryptoswap/calcs/factory_2_coin.py
@@ -68,6 +68,7 @@ def lp_price(virtual_price, price_oracle) -> int:
     return 2 * virtual_price * _sqrt_int(price_oracle) // 10**18
 
 
+# pylint: disable-next=too-many-locals
 def newton_y(  # noqa: complexity: 11
     ANN: int,
     gamma: int,
@@ -154,7 +155,7 @@ def newton_y(  # noqa: complexity: 11
     raise CalculationError("Did not converge")
 
 
-# pylint: disable=too-many-locals,too-many-branches
+# pylint: disable-next=too-many-locals,too-many-branches
 def newton_D(  # noqa: complexity: 13
     ANN: int,
     gamma: int,

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -5,7 +5,7 @@ import time
 from math import isqrt, prod
 from typing import List
 
-from curvesim.exceptions import CalculationError, CryptoPoolError
+from curvesim.exceptions import CalculationError, CryptoPoolError, CurvesimValueError
 from curvesim.logging import get_logger
 from curvesim.pool.base import Pool
 from curvesim.pool.snapshot import CurveCryptoPoolBalanceSnapshot
@@ -80,6 +80,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         admin_fee: int = 5 * 10**9,
         xcp_profit=10**18,
         xcp_profit_a=10**18,
+        virtual_price=None,
     ):
         """
         Parameters
@@ -137,6 +138,9 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             Counter for accumulated profits, no losses (default = 10**18)
         xcp_profit_a: int, optional
             Value of `xcp_profit` when admin fees last claimed (default = 10**18)
+        virtual_price: int, optional
+            amount of XCP invariant per LP token; can be used when
+            missing `tokens` value.
         """
         self.A = A
         self.gamma = gamma
@@ -195,13 +199,21 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             D = newton_D(A, gamma, xp)
             self.D = D
 
-        xcp = self._get_xcp(D)
-        if tokens is not None:
-            self.tokens = tokens
-        else:
-            self.tokens = xcp
+        if tokens and virtual_price:
+            raise CurvesimValueError(
+                "Should not set both `tokens` and `virtual_price`."
+            )
 
-        self.virtual_price = 10**18 * xcp // tokens
+        xcp = self._get_xcp(D)
+        if virtual_price:
+            self.virtual_price = virtual_price
+            self.tokens = xcp * 10**18 // virtual_price
+        else:
+            if tokens:
+                self.tokens = tokens
+            else:
+                self.tokens = xcp
+            self.virtual_price = 10**18 * xcp // self.tokens
 
     def _convert_D_to_balances(self, D):
         price_scale = self.price_scale

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -192,7 +192,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
                 )
         else:
             xp = self._xp()
-            D = factory_2_coin.newton_D(A, gamma, xp)
+            D = newton_D(A, gamma, xp)
             self.D = D
 
         xcp = self._get_xcp(D)

--- a/curvesim/pool/stableswap/metapool.py
+++ b/curvesim/pool/stableswap/metapool.py
@@ -5,6 +5,7 @@ from math import prod
 
 from gmpy2 import mpz
 
+from curvesim.exceptions import CurvesimValueError
 from curvesim.pool.snapshot import CurveMetaPoolBalanceSnapshot
 
 from ..base import Pool
@@ -44,6 +45,7 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         fee=4 * 10**6,
         fee_mul=None,
         admin_fee=0 * 10**9,
+        virtual_price=None,
     ):
         """
         Parameters
@@ -66,6 +68,9 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
             fee multiplier for dynamic fee pools
         admin_fee: int, optional
             percentage of `fee` with 10**10 precision (default = 50%)
+        virtual_price: int, optional
+            amount of D invariant per LP token; can be used when
+            missing `tokens` value.
         """
         # FIXME: set admin_fee default back to 5 * 10**9
         # once sim code is updated.  Right now we use 0
@@ -91,8 +96,21 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         else:
             self.balances = [D // n * 10**18 // _p for _p in self.rates]
 
+        if tokens and virtual_price:
+            raise CurvesimValueError(
+                "Should not set both `tokens` and `virtual_price`."
+            )
+
+        # By now, should have set everything needed for D.
+        D = self.D()
+        if tokens:
+            self.tokens = tokens
+        elif virtual_price:
+            self.tokens = D * 10**18 // virtual_price
+        else:
+            self.tokens = D
+
         self.n_total = n + basepool.n - 1
-        self.tokens = tokens
         self.fee_mul = fee_mul
         self.admin_balances = [0] * n
 

--- a/curvesim/pool/stableswap/metapool.py
+++ b/curvesim/pool/stableswap/metapool.py
@@ -33,7 +33,7 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         "admin_balances",
     )
 
-    # pylint: disable-next=too-many-arguments
+    # pylint: disable-next=too-many-arguments,duplicate-code
     def __init__(
         self,
         A,

--- a/curvesim/tools/bonding_curve.py
+++ b/curvesim/tools/bonding_curve.py
@@ -13,6 +13,7 @@ from curvesim.pool import CurveMetaPool
 D_UNIT = 10**18
 
 
+# pylint: disable-next=too-many-locals
 def bonding_curve(pool, *, truncate=0.0005, resolution=1000, plot=False):
     """
     Computes and optionally plots a pool's bonding curve and current reserves.


### PR DESCRIPTION
### Description

Fixed #219, a couple bugs in `CurveCryptoPool.__init__`.  Since we need it for #221, I also added `virtual_price` as an optional init kwarg for all pool types.  We can pull that value from the subgraph and combined with D, lets us compute the number of LP tokens later.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hips.hearstapps.com/hmg-prod/images/squirrel-nature-photos-1537973822.jpg?crop=1xw:1xh;center,top&resize=980:*)
