### PR TITLE
Use non-deprecated option with days

### DIFF
--- a/curvesim/metrics/metrics.py
+++ b/curvesim/metrics/metrics.py
@@ -510,7 +510,7 @@ class PoolValue(PoolPricingMetric):
 
     def compute_annualized_returns(self, data):
         """Computes annualized returns from a series of pool values."""
-        year_multipliers = timedelta64(1, "Y") / data.index.to_series().diff()
+        year_multipliers = timedelta64(365, "D") / data.index.to_series().diff()
         log_returns = log(data).diff()  # pylint: disable=no-member
 
         return exp((log_returns * year_multipliers).mean()) - 1


### PR DESCRIPTION
### Description

Numpy no longer allows the "Y" unit in its `timedelta` constructor, e.g. `timedelta64(1, 'Y')`, due to a "year" being an ambiguous number of nanoseconds.

We fix this by using `timedelta64(365, 'D')`, which does not materially impact our annualization calculation.


### Hygiene checklist

- [ ] <s>Changelog entry</s>
- [ ] <s>Everything public has a Numpy-style docstring</s>
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1453227588063-bb302b62f50b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1740&q=80)
