### PR TITLE
Move balancing logic from data processing to pool factory

### DIFF
--- a/changelog.d/20230910_184147_chanhosuh_stableswap_snapshot_fix.rst
+++ b/changelog.d/20230910_184147_chanhosuh_stableswap_snapshot_fix.rst
@@ -1,0 +1,42 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. -------
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+Fixed
+-----
+
+- Pool snapshot from subgraph was being augmented with some calculated values,
+  namely `tokens` and `D`.  This value was incorrect for stableswap metapools.
+
+  We have removed the augmented data and this is now being calculated as needed
+  in the factory function `get_sim_pool`.  This is used to initialize the pool
+  in a balanced state if desired.
+
+  The calculation relies on the pool's internal logic, which we test rigorously
+  in unit tests.
+
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20230910_184147_chanhosuh_stableswap_snapshot_fix.rst
+++ b/changelog.d/20230910_184147_chanhosuh_stableswap_snapshot_fix.rst
@@ -29,3 +29,6 @@ Fixed
   The calculation relies on the pool's internal logic, which we test rigorously
   in unit tests.
 
+- The value of `D` in the snapshot actually had a bug, so removing this fixes
+  that accidentally.
+

--- a/changelog.d/20230910_184147_chanhosuh_stableswap_snapshot_fix.rst
+++ b/changelog.d/20230910_184147_chanhosuh_stableswap_snapshot_fix.rst
@@ -1,27 +1,21 @@
-.. A new scriv changelog fragment.
-..
-.. Uncomment the header that is right (remove the leading dots).
-..
-.. Removed
-.. -------
-..
-.. - A bullet item for the Removed category.
-..
-.. Added
-.. -----
-..
-.. - A bullet item for the Added category.
-..
-.. Changed
-.. -------
-..
-.. - A bullet item for the Changed category.
-..
-.. Deprecated
-.. ----------
-..
-.. - A bullet item for the Deprecated category.
-..
+Added
+-----
+
+- Each pool now has an internal method to handle conversion of the invariant
+  to balances.  This is helpful for use by "friend" classes/functions such
+  as factory functions.
+
+Removed
+-------
+
+- The pool snapshot from subgraph is no longer being augmented with calculated
+  data (see "Fixed" section for a related bug).  The snapshot functionality
+  is solely limited to subgraph values with appropriate conversion into
+  python types.
+
+- Pool metadata no longer takes balancing options.  This is handled by the
+  the appropriate factory function, namely `get_sim_pool`.
+
 Fixed
 -----
 
@@ -35,8 +29,3 @@ Fixed
   The calculation relies on the pool's internal logic, which we test rigorously
   in unit tests.
 
-.. Security
-.. --------
-..
-.. - A bullet item for the Security category.
-..

--- a/curvesim/network/subgraph.py
+++ b/curvesim/network/subgraph.py
@@ -14,7 +14,7 @@ from curvesim.logging import get_logger
 from ..exceptions import CurvesimValueError, SubgraphResultError
 from ..overrides import override_subgraph_data
 from .http import HTTP
-from .utils import compute_D, sync
+from .utils import sync
 
 # pylint: disable=redefined-outer-name
 
@@ -344,9 +344,6 @@ async def pool_snapshot(address, chain, env="prod", end_ts=None):
     pool = r.pop("pool")
     r.update(pool)
 
-    # D
-    D = compute_D(r["normalizedReserves"], r["A"])
-
     # Version
     if r["isV2"]:
         version = 2
@@ -393,11 +390,9 @@ async def pool_snapshot(address, chain, env="prod", end_ts=None):
             },
             "coins": coins,
             "reserves": {
-                "D": D,
                 "by_coin": normalized_reserves,
                 "unnormalized_by_coin": unnormalized_reserves,
                 "virtual_price": int(r["virtualPrice"]),
-                "tokens": D * 10**18 // int(r["virtualPrice"]),
             },
             "basepool": basepool,
             "timestamp": int(r["timestamp"]),
@@ -445,11 +440,9 @@ async def pool_snapshot(address, chain, env="prod", end_ts=None):
             },
             "coins": coins,
             "reserves": {
-                "D": D,
                 "by_coin": normalized_reserves,
                 "unnormalized_by_coin": unnormalized_reserves,
                 "virtual_price": int(r["virtualPrice"]),
-                "tokens": D * 10**18 // int(r["virtualPrice"]),
             },
             "basepool": basepool,
             "timestamp": int(r["timestamp"]),

--- a/curvesim/pool/__init__.py
+++ b/curvesim/pool/__init__.py
@@ -259,6 +259,7 @@ def get_sim_pool(
 
     init_kwargs = pool_metadata.init_kwargs(normalize=True)
     logger.debug(init_kwargs)
+    print(init_kwargs)
 
     pool_type = pool_metadata.sim_pool_type
 
@@ -287,7 +288,7 @@ def get_sim_pool(
         new_D = pool.D()
     except TypeError:
         new_D = pool.D
-    # assert abs(new_D - D) < 5, f"old D: {D}, new D: {new_D}, diff: {new_D - D}"
+    assert abs(new_D - D) < 5, f"old D: {D}, new D: {new_D}, diff: {new_D - D}"
     try:
         new_vprice = pool.get_virtual_price()
     except AttributeError:

--- a/curvesim/pool/__init__.py
+++ b/curvesim/pool/__init__.py
@@ -147,18 +147,23 @@ def get_pool(
     env="prod",
 ):
     """
-    Constructs a pool object based on the stored data.
+    Factory function for creating a pool based on metadata pulled from on-chain.
 
     Parameters
     ----------
-    address : str
-        pool address prefixed with "0x"
+    pool_metadata : Union[str, dict, PoolMetaDataInterface]
+        pool address prefixed with "0x" or already pulled metadata in the form
+        of a dict or :class:`PoolMetaDataInterface`.
 
     chain: str, default="mainnet"
         chain/layer2 identifier, e.g. "mainnet", "arbitrum", "optimism"
 
     normalize : bool, default=False
         If True, normalizes balances to 18 decimals (useful for sim calculations).
+
+    end_ts: int, optional
+        Posix timestamp indicating the datetime of the metadata snapshot.
+        Only used when `pool_metadata` is an address.
 
     Returns
     -------
@@ -210,29 +215,41 @@ def get_sim_pool(
     env="prod",
 ):
     """
-    Effectively the same as the `get_pool` function but returns
-    an object in the `SimPool` hierarchy.
+    Factory function for creating a sim pool based on metadata pulled from on-chain.
 
     Parameters
     ----------
-    address : str
-        pool address prefixed with "0x"
+    pool_metadata : Union[str, dict, PoolMetaDataInterface]
+        pool address prefixed with "0x" or already pulled metadata in the form
+        of a dict or :class:`PoolMetaDataInterface`.
 
     chain: str, default="mainnet"
         chain/layer2 identifier, e.g. "mainnet", "arbitrum", "optimism"
 
-    balanced : bool, default=False
+    balanced : bool, default=True
         If True, balances the pool value across assets.
 
-    balanced_base : bool, default=False
+    balanced_base : bool, default=True
         If True and pool is metapool, balances the basepool value across assets.
 
-    normalize : bool, default=False
-        If True, normalizes balances to 18 decimals (useful for sim calculations).
+    end_ts: int, optional
+        Posix timestamp indicating the datetime of the metadata snapshot.
+        Only used when `pool_metadata` is an address.
+
+    custom_kwargs: dict, optional
+        Used for passing additional kwargs to the pool's `__init__`.
+
+    pool_data_cache: PoolDataCache, optional
+        Pass in custom type that pulls/holds market prices and volume.
+        This will be deprecated in the future.
 
     Returns
     -------
     :class:`SimPool`
+
+    Note
+    -----
+    The balances are always normalized to 18 decimals.
 
     Examples
     --------

--- a/curvesim/pool/__init__.py
+++ b/curvesim/pool/__init__.py
@@ -230,12 +230,9 @@ def get_sim_pool(
     normalize : bool, default=False
         If True, normalizes balances to 18 decimals (useful for sim calculations).
 
-    sim: bool, default=False
-        If True, returns a `SimPool` version of the pool.
-
     Returns
     -------
-    :class:`Pool`
+    :class:`SimPool`
 
     Examples
     --------

--- a/curvesim/pool/__init__.py
+++ b/curvesim/pool/__init__.py
@@ -27,7 +27,6 @@ __all__ = [
 
 from curvesim.exceptions import CurvesimValueError
 from curvesim.logging import get_logger
-from curvesim.network.utils import compute_D
 from curvesim.pool_data import get_metadata
 from curvesim.pool_data.metadata import PoolMetaData, PoolMetaDataInterface
 
@@ -259,7 +258,6 @@ def get_sim_pool(
 
     init_kwargs = pool_metadata.init_kwargs(normalize=True)
     logger.debug(init_kwargs)
-    print(init_kwargs)
 
     pool_type = pool_metadata.sim_pool_type
 
@@ -273,35 +271,6 @@ def get_sim_pool(
     pool = pool_type(**init_kwargs)
     pool.metadata = pool_metadata._dict  # pylint: disable=protected-access
     _balance_pool(pool, balanced, balanced_base)
-    # ---- start testing harness ------
-    print(pool.metadata)
-    if hasattr(pool, "basepool"):
-        bp_vprice = pool.basepool.metadata["reserves"]["virtual_price"]
-        balances = pool.metadata["reserves"]["by_coin"]
-        balances = [balances[0], balances[1] * bp_vprice // 10**18]
-        D = compute_D(balances, pool.A)
-    else:
-        D = compute_D(pool.metadata["reserves"]["by_coin"], pool.A)
-    virtual_price = pool.metadata["reserves"]["virtual_price"]
-    tokens = D * 10**18 // virtual_price
-    try:
-        new_D = pool.D()
-    except TypeError:
-        new_D = pool.D
-    assert abs(new_D - D) < 5, f"old D: {D}, new D: {new_D}, diff: {new_D - D}"
-    try:
-        new_vprice = pool.get_virtual_price()
-    except AttributeError:
-        new_vprice = pool.virtual_price
-    assert (
-        abs(new_vprice - virtual_price) < 5
-    ), f"old vp: {virtual_price}, new vp: {new_vprice}, diff: {new_vprice - virtual_price}"
-    assert pool.tokens == tokens, f"old token: {tokens}, new tokens: {pool.tokens}"
-    old_balances = pool._convert_D_to_balances(D)
-    assert (
-        old_balances == pool.balances
-    ), f"old balances: {old_balances}, new balances: {pool.balances}"
-    # ---- end testing harness ------
 
     return pool
 

--- a/curvesim/pool/__init__.py
+++ b/curvesim/pool/__init__.py
@@ -171,13 +171,15 @@ def get_pool(
     >>> chain = "mainnet"
     >>> pool = curvesim.pool.get(pool_address, chain)
     """
+    if end_ts and not isinstance(pool_metadata, str):
+        raise CurvesimValueError("`end_ts` has no effect unless pool address is used.")
+
     if isinstance(pool_metadata, str):
         pool_metadata = get_metadata(pool_metadata, chain=chain, env=env, end_ts=end_ts)
     elif isinstance(pool_metadata, dict):
         pool_metadata = PoolMetaData(pool_metadata)
-    elif isinstance(pool_metadata, PoolMetaDataInterface):
-        pass
-    else:
+
+    if not isinstance(pool_metadata, PoolMetaDataInterface):
         raise CurvesimValueError(
             "`pool_metadata` must be of type `str`, `dict`, or `PoolMetaDataInterface`."
         )

--- a/curvesim/pool/__init__.py
+++ b/curvesim/pool/__init__.py
@@ -276,13 +276,22 @@ def get_sim_pool(
 
     pool = pool_type(**init_kwargs)
 
-    pool.metadata = pool_metadata._dict  # pylint: disable=protected-access
+    # pylint: disable=protected-access
+    pool.metadata = pool_metadata._dict
 
     if balanced:
-        ...
+        try:
+            # stableswap/metapool
+            D = pool.D()
+        except TypeError:
+            # cryptopool
+            D = pool.D
+        pool.balances = pool._convert_D_to_balances(D)
 
-    if balanced_base:
-        ...
+    if balanced_base and hasattr(pool, "basepool"):
+        basepool = pool.basepool
+        D = basepool.D()
+        basepool.balances = basepool._convert_D_to_balances(D)
 
     return pool
 

--- a/curvesim/pool/stableswap/metapool.py
+++ b/curvesim/pool/stableswap/metapool.py
@@ -77,6 +77,7 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         # to pass the CI tests.
         self.A = A
         self.n = n
+
         self.max_coin = self.n - 1
         self.fee = fee
         self.admin_fee = admin_fee
@@ -94,7 +95,7 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         if isinstance(D, list):
             self.balances = D
         else:
-            self.balances = [D // n * 10**18 // _p for _p in self.rates]
+            self.balances = self._convert_D_to_balances(D)
 
         if tokens and virtual_price:
             raise CurvesimValueError(
@@ -113,6 +114,11 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         self.n_total = n + basepool.n - 1
         self.fee_mul = fee_mul
         self.admin_balances = [0] * n
+
+    def _convert_D_to_balances(self, D):
+        n = self.n
+        rates = self.rates
+        return [D // n * 10**18 // _p for _p in rates]
 
     def D(self, xp=None):
         """

--- a/curvesim/pool/stableswap/pool.py
+++ b/curvesim/pool/stableswap/pool.py
@@ -78,7 +78,7 @@ class CurvePool(Pool):  # pylint: disable=too-many-instance-attributes
         self.rates = rates
 
         if isinstance(D, list):
-            self.balances = D
+            self.balances = D.copy()
         else:
             self.balances = self._convert_D_to_balances(D)
 

--- a/curvesim/pool/stableswap/pool.py
+++ b/curvesim/pool/stableswap/pool.py
@@ -72,16 +72,15 @@ class CurvePool(Pool):  # pylint: disable=too-many-instance-attributes
         # to pass the CI tests.
         rates = rates or [10**18] * n
 
-        if isinstance(D, list):
-            balances = D
-        else:
-            balances = [D // n * 10**18 // _p for _p in rates]
-
         self.A = A
         self.n = n
         self.fee = fee
         self.rates = rates
-        self.balances = balances
+
+        if isinstance(D, list):
+            self.balances = D
+        else:
+            self.balances = self._convert_D_to_balances(D)
 
         if tokens and virtual_price:
             raise CurvesimValueError(
@@ -102,6 +101,11 @@ class CurvePool(Pool):  # pylint: disable=too-many-instance-attributes
         self.r = False
         self.n_total = n
         self.admin_balances = [0] * n
+
+    def _convert_D_to_balances(self, D):
+        n = self.n
+        rates = self.rates
+        return [D // n * 10**18 // _p for _p in rates]
 
     def _xp(self):
         rates = self.rates

--- a/curvesim/pool_data/metadata/base.py
+++ b/curvesim/pool_data/metadata/base.py
@@ -11,20 +11,12 @@ class PoolMetaDataInterface(ABC):
     """
 
     @abstractmethod
-    def init_kwargs(self, balanced=True, balanced_base=True, normalize=True):
+    def init_kwargs(self, normalize=True):
         """
         Returns a dictionary of kwargs used to initialize the pool.
 
         Parameters
         ----------
-        balanced: bool
-            Will derive balances corresponding to the pool's total value so
-            that it is balanced.
-        balanced_base: bool
-            For metapools only.
-
-            Will derive balances corresponding to the basepool's total value so
-            that it is balanced.
         normalize: bool
             Will put the balances in units of D, e.g. 18 decimals.
 

--- a/curvesim/pool_data/metadata/cryptoswap.py
+++ b/curvesim/pool_data/metadata/cryptoswap.py
@@ -8,14 +8,13 @@ logger = get_logger(__name__)
 class CryptoswapMetaData(PoolMetaDataBase):
     """Specific implementation of the `PoolMetaDataInterface` for Cryptoswap."""
 
-    def init_kwargs(self, balanced=True, balanced_base=True, normalize=True):
+    def init_kwargs(self, normalize=True):
         data = self._dict
 
         kwargs = {
             "A": data["params"]["A"],
             "gamma": data["params"]["gamma"],
             "n": len(data["coins"]["names"]),
-            "D": data["reserves"]["D"],
             "mid_fee": data["params"]["mid_fee"],
             "out_fee": data["params"]["out_fee"],
             "allowed_extra_profit": data["params"]["allowed_extra_profit"],
@@ -24,7 +23,7 @@ class CryptoswapMetaData(PoolMetaDataBase):
             "price_scale": data["params"]["price_scale"],
             "admin_fee": data["params"]["admin_fee"],
             "ma_half_time": data["params"]["ma_half_time"],
-            "tokens": data["reserves"]["tokens"],
+            "virtual_price": data["reserves"]["virtual_price"],
             "xcp_profit": data["params"]["xcp_profit"],
             "xcp_profit_a": data["params"]["xcp_profit_a"],
         }
@@ -35,12 +34,11 @@ class CryptoswapMetaData(PoolMetaDataBase):
         else:
             kwargs["precisions"] = [1] * n
 
-        if not balanced:
-            if normalize:
-                coin_balances = data["reserves"]["by_coin"]
-            else:
-                coin_balances = data["reserves"]["unnormalized_by_coin"]
-            kwargs["balances"] = coin_balances
+        if normalize:
+            coin_balances = data["reserves"]["by_coin"]
+        else:
+            coin_balances = data["reserves"]["unnormalized_by_coin"]
+        kwargs["balances"] = coin_balances
 
         return kwargs
 

--- a/curvesim/pool_data/metadata/stableswap.py
+++ b/curvesim/pool_data/metadata/stableswap.py
@@ -18,7 +18,11 @@ class StableswapMetaData(PoolMetaDataBase):
                 "virtual_price": data["reserves"]["virtual_price"],
             }
 
-            if not normalize:
+            if normalize:
+                coin_balances = data["reserves"]["by_coin"]
+            else:
+                coin_balances = data["reserves"]["unnormalized_by_coin"]
+
                 if data["basepool"]:
                     d = data["coins"]["decimals"][0]
                     kwargs["rate_multiplier"] = 10 ** (36 - d)
@@ -27,10 +31,6 @@ class StableswapMetaData(PoolMetaDataBase):
                         10 ** (36 - d) for d in data["coins"]["decimals"]
                     ]
 
-            if normalize:
-                coin_balances = data["reserves"]["by_coin"]
-            else:
-                coin_balances = data["reserves"]["unnormalized_by_coin"]
             kwargs["D"] = coin_balances
 
             return kwargs

--- a/curvesim/pool_data/metadata/stableswap.py
+++ b/curvesim/pool_data/metadata/stableswap.py
@@ -6,10 +6,10 @@ from .base import PoolMetaDataBase
 class StableswapMetaData(PoolMetaDataBase):
     """Specific implementation of the `PoolMetaDataInterface` for Stableswap."""
 
-    def init_kwargs(self, balanced=True, balanced_base=True, normalize=True):
+    def init_kwargs(self, normalize=True):
         data = self._dict
 
-        def process_to_kwargs(data, balanced, normalize):
+        def process_to_kwargs(data, normalize):
             kwargs = {
                 "A": data["params"]["A"],
                 "n": len(data["coins"]["names"]),
@@ -35,11 +35,11 @@ class StableswapMetaData(PoolMetaDataBase):
 
             return kwargs
 
-        kwargs = process_to_kwargs(data, balanced, normalize)
+        kwargs = process_to_kwargs(data, normalize)
 
         if data["basepool"]:
             bp_data = data["basepool"]
-            bp_kwargs = process_to_kwargs(bp_data, balanced_base, normalize)
+            bp_kwargs = process_to_kwargs(bp_data, normalize)
             basepool = CurvePool(**bp_kwargs)
             basepool.metadata = bp_data
             kwargs["basepool"] = basepool

--- a/curvesim/pool_data/metadata/stableswap.py
+++ b/curvesim/pool_data/metadata/stableswap.py
@@ -12,12 +12,12 @@ class StableswapMetaData(PoolMetaDataBase):
         def process_to_kwargs(data, balanced, normalize):
             kwargs = {
                 "A": data["params"]["A"],
-                "D": data["reserves"]["D"],
                 "n": len(data["coins"]["names"]),
                 "fee": data["params"]["fee"],
                 "fee_mul": data["params"]["fee_mul"],
-                "tokens": data["reserves"]["tokens"],
+                "virtual_price": data["reserves"]["virtual_price"],
             }
+
             if not normalize:
                 if data["basepool"]:
                     d = data["coins"]["decimals"][0]
@@ -26,12 +26,13 @@ class StableswapMetaData(PoolMetaDataBase):
                     kwargs["rates"] = [
                         10 ** (36 - d) for d in data["coins"]["decimals"]
                     ]
-            if not balanced:
-                if normalize:
-                    coin_balances = data["reserves"]["by_coin"]
-                else:
-                    coin_balances = data["reserves"]["unnormalized_by_coin"]
-                kwargs["D"] = coin_balances
+
+            if normalize:
+                coin_balances = data["reserves"]["by_coin"]
+            else:
+                coin_balances = data["reserves"]["unnormalized_by_coin"]
+            kwargs["D"] = coin_balances
+
             return kwargs
 
         kwargs = process_to_kwargs(data, balanced, normalize)

--- a/test/unit/test_pool_metadata.py
+++ b/test/unit/test_pool_metadata.py
@@ -27,7 +27,6 @@ POOL_TEST_METADATA_JSON = """
         "decimals": [18, 6, 6]
     },
     "reserves": {
-        "D": 435874505461314832883219554,
         "by_coin": [
             171485829393046867353492287,
             175414686134396000000000000,
@@ -38,8 +37,7 @@ POOL_TEST_METADATA_JSON = """
             175414686134396,
             88973989934190
         ],
-        "virtual_price": 1025499623208090719,
-        "tokens": 425036241454443455995211818
+        "virtual_price": 1025499623208090719
     },
     "basepool": null,
     "timestamp": 1677628800
@@ -65,11 +63,9 @@ METAPOOL_TEST_METADATA_JSON = """
             "decimals": [2, 18]
         },
         "reserves": {
-            "D": 9165154506890406219227550,
             "by_coin": [4580491420000000000000000, 4584663086890532793313572],
             "unnormalized_by_coin": [458049142, 4584663086890532793313572],
-            "virtual_price": 1002128768748324821,
-            "tokens": 9145685457506457679415433
+            "virtual_price": 1002128768748324821
         },
         "basepool": {
             "name": "Curve.fi FRAX/USDC",
@@ -94,11 +90,9 @@ METAPOOL_TEST_METADATA_JSON = """
                 "decimals": [18, 6]
             },
             "reserves": {
-                "D": 492801294421778420804073827,
                 "by_coin": [305660498155854651779818562, 187140798282666000000000000],
                 "unnormalized_by_coin": [305660498155854651779818562, 187140798282666],
-                "virtual_price": 1001200369105166674,
-                "tokens": 492210460192123924194896848
+                "virtual_price": 1001200369105166674
             },
             "basepool": null,
             "timestamp": 1677715200
@@ -141,11 +135,9 @@ CRYPTOPOOL_TEST_METADATA_JSON = """
         "decimals": [18, 6]
     },
     "reserves": {
-        "D": 18116170684879887969148488,
         "by_coin": [11278350350009782994292193, 6837820334873000000000000],
         "unnormalized_by_coin": [11278350350009782994292193, 6837820334873],
-        "virtual_price": 1036543672382221695,
-        "tokens": 17477479403491661243983086
+        "virtual_price": 1036543672382221695
     },
     "basepool": null,
     "timestamp": 1684108800
@@ -179,14 +171,6 @@ def test_pool():
 
     assert metadata.init_kwargs() == {
         "A": 2000,
-        "D": 435874505461314832883219554,
-        "n": 3,
-        "fee": 1000000,
-        "fee_mul": None,
-        "tokens": 425036241454443455995211818,
-    }
-    assert metadata.init_kwargs(balanced=False) == {
-        "A": 2000,
         "D": [
             171485829393046867353492287,
             175414686134396000000000000,
@@ -195,9 +179,9 @@ def test_pool():
         "n": 3,
         "fee": 1000000,
         "fee_mul": None,
-        "tokens": 425036241454443455995211818,
+        "virtual_price": 1025499623208090719,
     }
-    assert metadata.init_kwargs(balanced=False, normalize=False) == {
+    assert metadata.init_kwargs(normalize=False) == {
         "A": 2000,
         "D": [
             171485829393046867353492287,
@@ -207,7 +191,7 @@ def test_pool():
         "n": 3,
         "fee": 1000000,
         "fee_mul": None,
-        "tokens": 425036241454443455995211818,
+        "virtual_price": 1025499623208090719,
         "rates": [
             1000000000000000000,
             1000000000000000000000000000000,
@@ -237,30 +221,18 @@ def test_metapool():
     assert metadata.pool_type is CurveMetaPool
 
     init_kwargs = metadata.init_kwargs()
-    _ = init_kwargs.pop("basepool")
+    del init_kwargs["basepool"]
 
     assert init_kwargs == {
-        "A": 1500,
-        "D": 9165154506890406219227550,
-        "n": 2,
-        "fee": 4000000,
-        "fee_mul": None,
-        "tokens": 9145685457506457679415433,
-    }
-
-    unbalanced_init_kwargs = metadata.init_kwargs(balanced=False)
-    del unbalanced_init_kwargs["basepool"]
-
-    assert unbalanced_init_kwargs == {
         "A": 1500,
         "D": [4580491420000000000000000, 4584663086890532793313572],
         "n": 2,
         "fee": 4000000,
         "fee_mul": None,
-        "tokens": 9145685457506457679415433,
+        "virtual_price": 1002128768748324821,
     }
 
-    unnormalized_init_kwargs = metadata.init_kwargs(balanced=False, normalize=False)
+    unnormalized_init_kwargs = metadata.init_kwargs(normalize=False)
     del unnormalized_init_kwargs["basepool"]
 
     assert unnormalized_init_kwargs == {
@@ -269,7 +241,7 @@ def test_metapool():
         "n": 2,
         "fee": 4000000,
         "fee_mul": None,
-        "tokens": 9145685457506457679415433,
+        "virtual_price": 1002128768748324821,
         "rate_multiplier": 10000000000000000000000000000000000,
     }
 
@@ -294,25 +266,6 @@ def test_cryptopool():
     assert metadata.init_kwargs() == {
         "A": 400000,
         "gamma": 72500000000000,
-        "D": 18116170684879887969148488,
-        "n": 2,
-        "mid_fee": 26000000,
-        "out_fee": 45000000,
-        "adjustment_step": 146000000000000,
-        "allowed_extra_profit": 2000000000000,
-        "fee_gamma": 230000000000000,
-        "tokens": 17477479403491661243983086,
-        "ma_half_time": 600,
-        "price_scale": 1532848669525694314,
-        "admin_fee": 5000000000,
-        "xcp_profit": 1073065310463073367,
-        "xcp_profit_a": 1073065310463073367,
-        "precisions": [1, 1],
-    }
-    assert metadata.init_kwargs(balanced=False) == {
-        "A": 400000,
-        "gamma": 72500000000000,
-        "D": 18116170684879887969148488,
         "balances": [
             11278350350009782994292193,
             6837820334873000000000000,
@@ -323,7 +276,7 @@ def test_cryptopool():
         "adjustment_step": 146000000000000,
         "allowed_extra_profit": 2000000000000,
         "fee_gamma": 230000000000000,
-        "tokens": 17477479403491661243983086,
+        "virtual_price": 1036543672382221695,
         "ma_half_time": 600,
         "price_scale": 1532848669525694314,
         "admin_fee": 5000000000,
@@ -331,10 +284,9 @@ def test_cryptopool():
         "xcp_profit_a": 1073065310463073367,
         "precisions": [1, 1],
     }
-    assert metadata.init_kwargs(balanced=False, normalize=False) == {
+    assert metadata.init_kwargs(normalize=False) == {
         "A": 400000,
         "gamma": 72500000000000,
-        "D": 18116170684879887969148488,
         "balances": [
             11278350350009782994292193,
             6837820334873,
@@ -345,7 +297,7 @@ def test_cryptopool():
         "adjustment_step": 146000000000000,
         "allowed_extra_profit": 2000000000000,
         "fee_gamma": 230000000000000,
-        "tokens": 17477479403491661243983086,
+        "virtual_price": 1036543672382221695,
         "ma_half_time": 600,
         "price_scale": 1532848669525694314,
         "admin_fee": 5000000000,

--- a/test/unit/test_pool_metadata.py
+++ b/test/unit/test_pool_metadata.py
@@ -118,9 +118,9 @@ CRYPTOPOOL_TEST_METADATA_JSON = """
         "allowed_extra_profit": 2000000000000,
         "adjustment_step": 146000000000000,
         "ma_half_time": 600,
-        "price_scale": 1532848669525694314,
-        "price_oracle": 1629891359676425537,
-        "last_prices": 1625755383082188296,
+        "price_scale": [1532848669525694314],
+        "price_oracle": [1629891359676425537],
+        "last_prices": [1625755383082188296],
         "last_prices_timestamp": 1684107935,
         "admin_fee": 5000000000,
         "xcp_profit": 1073065310463073367,
@@ -144,9 +144,62 @@ CRYPTOPOOL_TEST_METADATA_JSON = """
 }
 """
 
+TRICRYPTO_NG_TEST_METADATA_JSON = """
+{
+    "name": "TriCRV",
+    "address": "0x4eBdF703948ddCEA3B11f675B4D1Fba9d2414A14",
+    "chain": "mainnet",
+    "symbol": "crvUSDETHCRV",
+    "version": 2,
+    "pool_type": "TRICRYPTO_FACTORY",
+    "params": {
+        "A": 2700000,
+        "gamma": 1300000000000,
+        "fee_gamma": 350000000000000,
+        "mid_fee": 2999999,
+        "out_fee": 80000000,
+        "allowed_extra_profit": 100000000000,
+        "adjustment_step": 100000000000,
+        "ma_half_time": 600,
+        "price_scale": [1649177296373068449425, 446562202678699631],
+        "price_oracle": [1648041807040538375682, 447066843075586148],
+        "last_prices": [1645044680220385710284, 446876572801432826],
+        "last_prices_timestamp": 1694130839,
+        "admin_fee": 5000000000,
+        "xcp_profit": 1018853337326661730,
+        "xcp_profit_a": 1018852684256364084
+    },
+    "coins": {
+        "names": ["crvUSD", "WETH", "CRV"],
+        "addresses": [
+            "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+            "0xD533a949740bb3306d119CC777fa900bA034cd52"
+        ],
+        "decimals": [18, 18, 18]
+    },
+    "reserves": {
+        "by_coin": [
+            3724679717441585468224357,
+            2268620966125133833261,
+            8327951931226366295069133
+        ],
+        "unnormalized_by_coin": [
+            3724679717441585468224357,
+            2268620966125133833261,
+            8327951931226366295069133
+        ],
+        "virtual_price": 1027263450430060608
+    },
+    "basepool": null,
+    "timestamp": 1694131200
+}
+"""
+
 pool_test_metadata = json.loads(POOL_TEST_METADATA_JSON)
 metapool_test_metadata = json.loads(METAPOOL_TEST_METADATA_JSON)
 cryptopool_test_metadata = json.loads(CRYPTOPOOL_TEST_METADATA_JSON)
+tricrypto_ng_test_metadata = json.loads(TRICRYPTO_NG_TEST_METADATA_JSON)
 
 
 def test_pool():
@@ -278,7 +331,7 @@ def test_cryptopool():
         "fee_gamma": 230000000000000,
         "virtual_price": 1036543672382221695,
         "ma_half_time": 600,
-        "price_scale": 1532848669525694314,
+        "price_scale": [1532848669525694314],
         "admin_fee": 5000000000,
         "xcp_profit": 1073065310463073367,
         "xcp_profit_a": 1073065310463073367,
@@ -299,7 +352,7 @@ def test_cryptopool():
         "fee_gamma": 230000000000000,
         "virtual_price": 1036543672382221695,
         "ma_half_time": 600,
-        "price_scale": 1532848669525694314,
+        "price_scale": [1532848669525694314],
         "admin_fee": 5000000000,
         "xcp_profit": 1073065310463073367,
         "xcp_profit_a": 1073065310463073367,
@@ -307,4 +360,68 @@ def test_cryptopool():
             1,
             1000000000000,
         ],
+    }
+
+
+def test_tricrypto_ng():
+    metadata = PoolMetaData(tricrypto_ng_test_metadata)
+
+    assert metadata.address == "0x4eBdF703948ddCEA3B11f675B4D1Fba9d2414A14"
+    assert metadata.chain == "mainnet"
+
+    assert metadata.pool_type == CurveCryptoPool
+    assert metadata.sim_pool_type == SimCurveCryptoPool
+
+    assert metadata.coin_names == ["crvUSD", "WETH", "CRV"]
+    assert metadata.coins == [
+        "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
+        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "0xD533a949740bb3306d119CC777fa900bA034cd52",
+    ]
+
+    assert metadata.n == 3
+
+    assert metadata.init_kwargs() == {
+        "A": 2700000,
+        "gamma": 1300000000000,
+        "balances": [
+            3724679717441585468224357,
+            2268620966125133833261,
+            8327951931226366295069133,
+        ],
+        "n": 3,
+        "mid_fee": 2999999,
+        "out_fee": 80000000,
+        "adjustment_step": 100000000000,
+        "allowed_extra_profit": 100000000000,
+        "fee_gamma": 350000000000000,
+        "virtual_price": 1027263450430060608,
+        "ma_half_time": 600,
+        "price_scale": [1649177296373068449425, 446562202678699631],
+        "admin_fee": 5000000000,
+        "xcp_profit": 1018853337326661730,
+        "xcp_profit_a": 1018852684256364084,
+        "precisions": [1, 1, 1],
+    }
+    assert metadata.init_kwargs(normalize=False) == {
+        "A": 2700000,
+        "gamma": 1300000000000,
+        "balances": [
+            3724679717441585468224357,
+            2268620966125133833261,
+            8327951931226366295069133,
+        ],
+        "n": 3,
+        "mid_fee": 2999999,
+        "out_fee": 80000000,
+        "adjustment_step": 100000000000,
+        "allowed_extra_profit": 100000000000,
+        "fee_gamma": 350000000000000,
+        "virtual_price": 1027263450430060608,
+        "ma_half_time": 600,
+        "price_scale": [1649177296373068449425, 446562202678699631],
+        "admin_fee": 5000000000,
+        "xcp_profit": 1018853337326661730,
+        "xcp_profit_a": 1018852684256364084,
+        "precisions": [1, 1, 1],
     }


### PR DESCRIPTION
### Description

Pool snapshot from subgraph was being augmented with some calculated values, namely `tokens` and `D`.  This value was incorrect for stableswap metapools (due to not converting using vprice) and for regular stableswap (by type error).  We have removed the augmented data and this is now being calculated as needed in the factory function `get_sim_pool` by invoking the pool's internal logic, which we rigorously test with unit tests.  This is used to initialize the pool in a balanced state if desired.

The snapshot functionality is now solely limited to subgraph values with appropriate conversion into python types.

Each pool now has an internal method to handle conversion of the invariant to balances.  This is helpful for use by "friend" classes/functions such as factory functions, e.g. `get_sim_pool`.

Pool metadata no longer takes balancing options.  This is handled by `get_sim_pool`.

#234 should be merged first.

This PR closes #220, closes #221.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/474x/51/0b/dc/510bdcc50831630d35c3f1aa723a2d96.jpg)
