### PR TITLE
Tricrypto calc token amount

### DIFF
--- a/changelog.d/20230911_134626_philiplu97_tricrypto_calc_token_amount.rst
+++ b/changelog.d/20230911_134626_philiplu97_tricrypto_calc_token_amount.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+Added
+-----
+
+- Tested calc_token_amount for 3-coin pools in test_tricrypto using test_calc_token_amount.
+
+Changed
+-------
+
+- CurveCryptoPool can use calc_token_amount to determine LP tokens minted on deposits for 3-coin pools now.
+
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -1046,7 +1046,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         D: int = newton_D(A, gamma, xp)
         d_token: int = token_supply * D // D0 - token_supply
         d_token -= self._calc_token_fee(amountsp, xp) * d_token // 10**10 + 1
-        
+
         return d_token
 
     def dydxfee(self, i, j):

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -1028,6 +1028,10 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         -------
         int
             Amount of LP tokens minted.
+
+        Note
+        ----
+        This is a "view" function; it doesn't change the state of the pool.
         """
         token_supply: int = self.tokens
         A: int = self.A
@@ -1035,11 +1039,14 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         xp: List[int] = self._xp()
         amountsp: List[int] = self._xp_mem(amounts)
         D0: int = self.D
+
         for i, a in enumerate(amountsp):
             xp[i] += a
+
         D: int = newton_D(A, gamma, xp)
         d_token: int = token_supply * D // D0 - token_supply
         d_token -= self._calc_token_fee(amountsp, xp) * d_token // 10**10 + 1
+        
         return d_token
 
     def dydxfee(self, i, j):

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -1030,14 +1030,14 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             Amount of LP tokens minted.
         """
         token_supply: int = self.tokens
-        A = self.A
-        gamma = self.gamma
+        A: int = self.A
+        gamma: int = self.gamma
         xp: List[int] = self._xp()
-        amountsp = self._xp_mem(amounts)
+        amountsp: List[int] = self._xp_mem(amounts)
         D0: int = self.D
         for i, a in enumerate(amountsp):
             xp[i] += a
-        D: int = factory_2_coin.newton_D(A, gamma, xp)
+        D: int = newton_D(A, gamma, xp)
         d_token: int = token_supply * D // D0 - token_supply
         d_token -= self._calc_token_fee(amountsp, xp) * d_token // 10**10 + 1
         return d_token

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -170,6 +170,7 @@ positive_balance = st.integers(min_value=10**5 * D_UNIT, max_value=10**11 * D_UN
 amplification_coefficient = st.integers(min_value=MIN_A, max_value=MAX_A)
 gamma_coefficient = st.integers(min_value=MIN_GAMMA, max_value=MAX_GAMMA)
 price = st.integers(min_value=10**12, max_value=10**25)
+bps_change = st.integers(min_value=0, max_value=100 * 100)
 
 
 @given(positive_balance, positive_balance)
@@ -669,20 +670,30 @@ def test_get_virtual_price(
     assert virtual_price == expected_virtual_price
 
 
-@given(positive_balance, positive_balance)
+@given(bps_change, bps_change)
 @settings(
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.filter_too_much,
+    ],
     max_examples=5,
     deadline=None,
 )
-def test_calc_token_amount(vyper_cryptopool, x0, x1):
+def test_calc_token_amount(vyper_cryptopool, x0_perc, x1_perc):
     """Test `calc_token_amount` against vyper implementation."""
-    assume(0.02 < x0 / x1 < 50)
-    xp = [x0, x1]
+    n_coins = 2
+    percents = [x0_perc, x1_perc]
+
+    assume(not (x0_perc == 0 and x1_perc == 0))
+
+    amountsp = [
+        percent * xp // 10000
+        for percent, xp in zip(percents, vyper_cryptopool.internal.xp())
+    ]
 
     precisions = vyper_cryptopool.eval("self._get_precisions()")
     price_scale = vyper_cryptopool.price_scale()
-    amounts = get_real_balances(xp, precisions, price_scale)
+    amounts = get_real_balances(amountsp, precisions, price_scale)
 
     pool = initialize_pool(vyper_cryptopool)
 
@@ -690,7 +701,7 @@ def test_calc_token_amount(vyper_cryptopool, x0, x1):
     lp_amount = pool.calc_token_amount(amounts)
     assert lp_amount == expected_lp_amount
 
-    expected_balances = [vyper_cryptopool.balances(i) for i in range(2)]
+    expected_balances = [vyper_cryptopool.balances(i) for i in range(n_coins)]
     assert pool.balances == expected_balances
 
 


### PR DESCRIPTION
### Description

- Adapted `CurveCryptoPool.calc_token_amount` to  3-coin sims. 
- Tested with `test_tricrypto.test_calc_token_amount` as a sanity check.

Closes #216.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/QIFci2V6MH1qSIcIEpGOilnCBCbzWs-WPIyHwiAvJaw/rs:fit:860:0:0/g:ce/aHR0cHM6Ly93d3cu/dGhlc3BydWNlcGV0/cy5jb20vdGhtYi9W/bFJsb2stQlJEMWps/YTVPNTdMckpNLURK/ZVU9LzcwMHgwL2Zp/bHRlcnM6bm9fdXBz/Y2FsZSgpOnN0cmlw/X2ljYygpLzMzMzMz/NDU1XzM3NjQ1NzQz/Mjg3NDg5Nl8xNDcz/ODU2NTEwNTI5Mzcy/MTYwX24tNWIxN2Q3/MjIxZDY0MDQwMDM2/MjYwNGU5LmpwZw)
