### PR TITLE
Create separate copies for diff state vars

### DIFF
--- a/changelog.d/20230911_183852_chanhosuh_simpool_mutation_bug.rst
+++ b/changelog.d/20230911_183852_chanhosuh_simpool_mutation_bug.rst
@@ -1,0 +1,5 @@
+Fixed
+-----
+
+- Fixed bug in `SimCurveCryptoPool.prepare_for_run` where the different price-related
+  state variables were initialized pointing to the same object.

--- a/curvesim/pool/sim_interface/cryptoswap.py
+++ b/curvesim/pool/sim_interface/cryptoswap.py
@@ -194,9 +194,9 @@ class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
         initial_prices = prices.iloc[0, 0 : n - 1].tolist()
         initial_prices = [int(10**18 / p) for p in initial_prices]
 
-        self.last_prices = initial_prices
-        self.price_scale = initial_prices
-        self._price_oracle = initial_prices
+        self.last_prices = initial_prices.copy()
+        self.price_scale = initial_prices.copy()
+        self._price_oracle = initial_prices.copy()
 
         # Upbdate balances, preserving xcp
         initial_prices_root = [root(p) for p in initial_prices]


### PR DESCRIPTION
### Description

Fixes #238.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://121clicks.com/wp-content/uploads/2021/10/cutest_animals_aww_reddit_group_12.jpg)
