### PR TITLE
Reduce cov score by 1% during fail-under check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload coverage badge
         uses: schneegans/dynamic-badges-action@v1.6.0
-        if: github.ref == 'refs/heads/main'
+        if: $${{ github.ref == 'refs/heads/main' && env.COVERAGE_SCORE > (env.OLD_COVERAGE_SCORE + 1) }}
         with:
           auth: ${{ secrets.GIST_TOKEN }}  # personal access token with scope "gist"
           gistID: 3da3c072e081f4509ebdd09c63e6ede5  # id of previously created gist

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,9 +147,13 @@ jobs:
           # and checks if score decreased since last CI run
           coverage combine --append
           BADGE_JSON=`cat ${{ steps.covbadge.outputs.file }}`
-          COVERAGE_SCORE=$(python3 -c "import json; score=json.loads('${BADGE_JSON}')['message'].rstrip('%'); print(score)")
-          coverage report --fail-under="${COVERAGE_SCORE:-0}"
-          echo "COVERAGE_SCORE=`coverage report --format=total`" >> $GITHUB_ENV
+          OLD_SCORE=$(python3 -c "import json; score=json.loads('${BADGE_JSON}')['message'].rstrip('%'); print(score)")
+          # Reduce score slightly to accomodate fluctuations
+          ADJUSTED_OLD_SCORE=$((OLD_SCORE-1))
+          coverage report --fail-under="${ADJUSTED_OLD_SCORE:-0}"
+          NEW_SCORE=$(coverage report --format=total)
+          echo "OLD_COVERAGE_SCORE=${OLD_SCORE}" >> $GITHUB_ENV
+          echo "COVERAGE_SCORE=${NEW_SCORE}" >> $GITHUB_ENV
 
       - name: Upload coverage badge
         uses: schneegans/dynamic-badges-action@v1.6.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,16 +148,19 @@ jobs:
           coverage combine --append
           BADGE_JSON=`cat ${{ steps.covbadge.outputs.file }}`
           OLD_SCORE=$(python3 -c "import json; score=json.loads('${BADGE_JSON}')['message'].rstrip('%'); print(score)")
-          # Reduce score slightly to accomodate fluctuations
-          ADJUSTED_OLD_SCORE=$((OLD_SCORE-1))
-          coverage report --fail-under="${ADJUSTED_OLD_SCORE:-0}"
+          # Use a "band" around the old score to account for fluctuations
+          OLD_SCORE_LOWER=$((OLD_SCORE-1))
+          OLD_SCORE_UPPER=$((OLD_SCORE+1))
+          # Use low bound to test score doesn't decrease significantly
+          coverage report --fail-under="${OLD_SCORE_LOWER:-0}"
           NEW_SCORE=$(coverage report --format=total)
-          echo "OLD_COVERAGE_SCORE=${OLD_SCORE}" >> $GITHUB_ENV
+          # Save upper bound for comparison: only save score if increase is significant
+          echo "OLD_COVERAGE_SCORE=${OLD_SCORE_UPPER}" >> $GITHUB_ENV
           echo "COVERAGE_SCORE=${NEW_SCORE}" >> $GITHUB_ENV
 
       - name: Upload coverage badge
         uses: schneegans/dynamic-badges-action@v1.6.0
-        if: $${{ github.ref == 'refs/heads/main' && env.COVERAGE_SCORE > (env.OLD_COVERAGE_SCORE + 1) }}
+        if: ${{ github.ref == 'refs/heads/main' && env.COVERAGE_SCORE > env.OLD_COVERAGE_SCORE }}
         with:
           auth: ${{ secrets.GIST_TOKEN }}  # personal access token with scope "gist"
           gistID: 3da3c072e081f4509ebdd09c63e6ede5  # id of previously created gist


### PR DESCRIPTION
Coverage score often fluctuates for small changes, which can cause the check to fail for no good reason.

### Description

Explain what you did and why, ser.


### Hygiene checklist

- [ ] Changelog entry
- [ ] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [ ] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
