### PR TITLE
Fix mutation bug in `CurveCryptoPool.__init__`

### DIFF
--- a/changelog.d/20230912_155707_chanhosuh_crypto_init_bug.rst
+++ b/changelog.d/20230912_155707_chanhosuh_crypto_init_bug.rst
@@ -1,0 +1,5 @@
+Fixed
+-----
+
+- Fixed bug in `CurveCryptoPool.__init__` where the different price-related
+  state variables were initialized pointing to the same object (#237).

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -152,9 +152,9 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         self.adjustment_step = adjustment_step
         self.admin_fee = admin_fee
 
-        self.price_scale = price_scale
-        self._price_oracle = price_oracle or price_scale
-        self.last_prices = last_prices or price_scale
+        self.price_scale = price_scale.copy()
+        self._price_oracle = price_oracle.copy() if price_oracle else price_scale.copy()
+        self.last_prices = last_prices.copy() if last_prices else price_scale.copy()
         self.ma_half_time = ma_half_time
 
         self._block_timestamp = _get_unix_timestamp()
@@ -181,7 +181,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         # calculations should have been set by this point.
 
         if balances:
-            self.balances = balances
+            self.balances = balances.copy()
 
         if D is not None:
             self.D = D


### PR DESCRIPTION
### Description

Fixes #237.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
