### PR TITLE
Set cryptoswap virtual price and profit to 1 at sim run start

### DIFF
--- a/changelog.d/20230912_180357_nagakingg_reset_counters.rst
+++ b/changelog.d/20230912_180357_nagakingg_reset_counters.rst
@@ -1,0 +1,6 @@
+
+Changed
+-------
+
+- Set cryptoswap virtual price and profit to 1 at sim run start (prepare_for_run)
+

--- a/curvesim/pool/sim_interface/cryptoswap.py
+++ b/curvesim/pool/sim_interface/cryptoswap.py
@@ -19,6 +19,8 @@ class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
     a generic interface (`SimPool`).
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -201,16 +203,17 @@ class SimCurveCryptoPool(SimPool, AssetIndicesMixin, CurveCryptoPool):
         # Upbdate balances, preserving xcp
         initial_prices_root = [root(p) for p in initial_prices]
         new_D = prod(initial_prices_root) * xcp * n // 10 ** (18 * (n - 1))
-        balances = self._convert_D_to_balances(new_D)
-        self.balances = balances
+        self.balances = self._convert_D_to_balances(new_D)
 
-        # Recompute and store D & virtual_price
-        xp = self._xp()  # pylint: disable=protected-access
-        computed_D = newton_D(self.A, self.gamma, xp)
-        self.D = computed_D
+        # Recompute D with new balances
+        xp = self._xp()
+        self.D = newton_D(self.A, self.gamma, xp)
 
-        virtual_price = self.get_virtual_price()
-        self.virtual_price = virtual_price
+        # Set virtual price & xcp profit to 1
+        self.tokens = self._get_xcp(self.D)
+        self.virtual_price = self.get_virtual_price()
+        self.xcp_profit = 10**18
+        self.xcp_profit_a = 10**18
 
     @property
     @override

--- a/test/unit/test_prepare_for_run.py
+++ b/test/unit/test_prepare_for_run.py
@@ -60,7 +60,11 @@ def test_cryptoswap3_prepare_for_run_high_price(sim_curve_tricrypto_pool, scalar
 
 
 def _test_cryptoswap_prepare_for_run_same_price(pool):
-    """Test that preserving price_scale doesn't change D or xcp(D)"""
+    """
+    Test that preserving price_scale doesn't change D or xcp(D);
+    and that virtual_price and xcp_profits are 10**18.
+    """
+    # pylint: disable=protected-access
 
     original_D = pool.D
     original_xcp = pool._get_xcp(pool.D)
@@ -82,10 +86,18 @@ def _test_cryptoswap_prepare_for_run_same_price(pool):
     assert abs(pool.D - original_D) < 10**10
     assert abs(new_xcp - original_xcp) < 10**10
 
+    # Test that virtual price and xcp_profits == 1
+    assert pool.virtual_price == 10**18
+    assert pool.xcp_profit == 10**18
+    assert pool.xcp_profit_a == 10**18
+
 
 def _test_cryptoswap_prepare_for_run(pool, scalar):
-    """Test that changing price_scale doesn't change xcp(D), but changes D"""
-
+    """
+    Test that changing price_scale doesn't change xcp(D), but changes D;
+    and that virtual_price and xcp_profits are 10**18.
+    """
+    # pylint: disable=protected-access
     original_D = pool.D
     original_xcp = pool._get_xcp(pool.D)
     new_price_scale = [int(p * scalar) for p in pool.price_scale]
@@ -106,7 +118,12 @@ def _test_cryptoswap_prepare_for_run(pool, scalar):
     assert abs(pool.D - original_D) > 10**10
     assert abs(new_xcp - original_xcp) < 10**10
 
+    # Test that virtual price and xcp_profits == 1
+    assert pool.virtual_price == 10**18
+    assert pool.xcp_profit == 10**18
+    assert pool.xcp_profit_a == 10**18
+
 
 def _test_list_equality(list1, list2, tol=10**10):
     """Test that differences are < tol for all elements"""
-    assert all([abs(val1 - val2) < tol for val1, val2 in zip(list1, list2)])
+    assert all(abs(val1 - val2) < tol for val1, val2 in zip(list1, list2))


### PR DESCRIPTION

### Description

- Set cryptoswap virtual price and profit to 1 at sim run start (prepare_for_run)
- Include test for this in unit/test_prepare_for_run

Closes #213 and #224 


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBerjNltXNr1J86aRqyAwJbKP06USBDLMhwQ&usqp=CAU)
