### PR TITLE
Tricrypto get dy

### DIFF
--- a/changelog.d/20230915_154021_philiplu97_tricrypto_get_dy.rst
+++ b/changelog.d/20230915_154021_philiplu97_tricrypto_get_dy.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+Added
+-----
+
+- Enabled get_dy for 3-coin CurveCryptoPools.
+
+.. Changed
+.. -------
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/curvesim/pool/cryptoswap/calcs/__init__.py
+++ b/curvesim/pool/cryptoswap/calcs/__init__.py
@@ -61,11 +61,17 @@ def newton_D(A: int, gamma: int, xp: List[int], K0_prev: int = 0) -> int:
 
 
 def get_y(A: int, gamma: int, xp: List[int], D: int, j: int) -> List[int]:
-    n_coins = len(xp)
+    """
+    Compute an xp[j] that satisfies the Cryptoswap invariant.
+
+    newton_y (for n = 2) and get_y (for n = 3) results may differ by
+    2 wei or so as their computational approaches are vastly different.
+    """
+    n_coins: int = len(xp)
     if n_coins == 2:
-        y_out = [factory_2_coin.newton_y(A, gamma, xp, D, j), 0]
+        y_out: List[int] = [factory_2_coin.newton_y(A, gamma, xp, D, j), 0]
     elif n_coins == 3:
-        y_out = tricrypto_ng.get_y(A, gamma, xp, D, j)
+        y_out: List[int] = tricrypto_ng.get_y(A, gamma, xp, D, j)
     else:
         raise CurvesimValueError("More than 3 coins is not supported.")
 

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -256,7 +256,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
 
         Note
         -----
-        This intentionally always return a new copy of the balances.
+        This intentionally always returns a new copy of the balances.
         """
         precisions = self.precisions
         price_scale = self.price_scale
@@ -501,11 +501,11 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         xp[i] += dx
         xp = self._xp_mem(xp)
 
-        A = self.A
-        gamma = self.gamma
+        A: int = self.A
+        gamma: int = self.gamma
         D: int = self.D
 
-        y: int = factory_2_coin.newton_y(A, gamma, xp, D, j)
+        y: int = get_y(A, gamma, xp, D, j)
         dy: int = xp[j] - y - 1
         xp[j] = y
         precisions: List[int] = self.precisions
@@ -575,10 +575,10 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             )
         else:
             _sum_xp: int = sum(xp)
-            K = 10**18
+            K: int = 10**18
             for _x in xp:
                 K = K * n_coins * _x // _sum_xp
-            f = fee_gamma * 10**18 // (fee_gamma + 10**18 - K)
+            f: int = fee_gamma * 10**18 // (fee_gamma + 10**18 - K)
         return (self.mid_fee * f + self.out_fee * (10**18 - f)) // 10**18
 
     # pylint: disable-next=too-many-locals

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -505,7 +505,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         gamma: int = self.gamma
         D: int = self.D
 
-        y: int = get_y(A, gamma, xp, D, j)
+        y: int = get_y(A, gamma, xp, D, j)[0]
         dy: int = xp[j] - y - 1
         xp[j] = y
         precisions: List[int] = self.precisions

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -484,6 +484,7 @@ def test_get_dy(vyper_cryptopool, x0, x1, dx_perc, i):
     """Test get_dy calculation against vyper implementation."""
     assume(0.02 < x0 / x1 < 50)
 
+    n_coins = 2
     j = 1 - i
     xp = [x0, x1]
 
@@ -495,14 +496,14 @@ def test_get_dy(vyper_cryptopool, x0, x1, dx_perc, i):
     update_cached_values(vyper_cryptopool)
     pool = initialize_pool(vyper_cryptopool)
 
-    dx = balances[i] * dx_perc // 10**5
+    dx = balances[i] * dx_perc // 10**4
 
     expected_dy = vyper_cryptopool.get_dy(i, j, dx)
     dy = pool.get_dy(i, j, dx)
 
     assert dy == expected_dy
 
-    expected_balances = [vyper_cryptopool.balances(i) for i in range(2)]
+    expected_balances = [vyper_cryptopool.balances(i) for i in range(n_coins)]
     assert pool.balances == expected_balances
 
 


### PR DESCRIPTION
### Description

Closes #214.

- Enabled and tested `get_dy` for 3-coin `CurveCryptoPool`s. 


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/1BGWFRDOVCXYWykMO_vfKQJ8XRfhqvdkUMWrq2gG0T0/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9pbWFn/ZXMudW5zcGxhc2gu/Y29tL3Bob3RvLTE1/NzgyNzI2NzgwODkt/NTIzYjI1ZjRiY2Zj/P2l4bGliPXJiLTQu/MC4zJml4aWQ9TTN3/eE1qQTNmREI4TUh4/elpXRnlZMmg4T0h4/OGFHVnVKVEl3WVc1/a0pUSXdZMmhwWTJ0/OFpXNThNSHg4TUh4/OGZEQT0mdz0xMDAw/JnE9ODA)
