### PR TITLE
Tricrypto calc withdraw

### DIFF
--- a/changelog.d/20230920_130325_philiplu97_tricrypto_calc_withdraw.rst
+++ b/changelog.d/20230920_130325_philiplu97_tricrypto_calc_withdraw.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+- Adapted CurveCryptoPool's _calc_withdraw_one_coin method to 3 coins.
+

--- a/changelog.d/20230920_130325_philiplu97_tricrypto_calc_withdraw.rst
+++ b/changelog.d/20230920_130325_philiplu97_tricrypto_calc_withdraw.rst
@@ -3,3 +3,9 @@ Added
 
 - Adapted CurveCryptoPool's _calc_withdraw_one_coin method to 3 coins.
 
+Changed
+-------
+- In CurveCryptoPool, changed _tweak_price's param p_i to be Optional[int], where a 
+  None value tells _tweak_price to calculate last prices from spot prices and a 0
+  indicates an error in the calculation pipeline.
+

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -908,12 +908,12 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         update_D: bool
             Switch for recomputing `D` during calculation.
         calc_price: bool
-            Switch for recomputing the price of token `i` after simulating a 
+            Switch for recomputing the price of token `i` after simulating a
             withdrawal. Only does something if `n` = 2.
 
         Returns
         -------
-        int 
+        int
             Output amount of the `i`-th coin.
         Optional[int]
             Price of the `i`-th coin after the withdrawal.
@@ -924,8 +924,8 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
 
         Note
         ----
-        The 3-coin pool contract doesn't have calc_price even though the 2-coin one 
-        does, so the price value returned is `None` when the price calculation doesn't 
+        The 3-coin pool contract doesn't have calc_price even though the 2-coin one
+        does, so the price value returned is `None` when the price calculation doesn't
         occur.
 
         This is a "view" function; it doesn't change the state of the pool.
@@ -951,7 +951,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             fee: int = self._fee(xp)
         elif self.n == 3:
             # For n = 3, charge max fee if xp_correction > xp_imprecise[i]
-            # Specifically, if % of xp[i] withdrawn > 1/n = 1/3 
+            # Specifically, if % of xp[i] withdrawn > 1/n = 1/3
             # Otherwise, _fee() underflows
             n_coins: int = self.n
             xp_imprecise: List[int] = xp.copy()
@@ -963,13 +963,15 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             else:
                 fee = self.out_fee
         else:
-            raise CalculationError("_calc_withdraw_one_coin doesn't support more than \
-            3 coins")
+            raise CalculationError(
+                "_calc_withdraw_one_coin doesn't support more than \
+            3 coins"
+            )
 
         # Charge fee on D, not on y, e.g. reducing invariant LESS than charging user
         dD: int = token_amount * D // token_supply
         D_fee: int = fee * dD // (2 * 10**10) + 1
-        D -= (dD - D_fee)
+        D -= dD - D_fee
         y: int = get_y(A, gamma, xp, D, i)[0]
         if i == 0:
             dy: int = (xp[i] - y) // precisions[i]
@@ -1012,7 +1014,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         -------
         int
             Output amount of the `i`-th coin.
-        
+
         Note
         ----
         This is a "view" function; it doesn't change the state of the pool.

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -3,7 +3,7 @@ Mainly a module to house the `CurveCryptoPool`, a cryptoswap implementation in P
 """
 import time
 from math import isqrt, prod
-from typing import List, Tuple, Type, Optional
+from typing import List, Optional, Tuple, Type
 
 from curvesim.exceptions import CalculationError, CryptoPoolError, CurvesimValueError
 from curvesim.logging import get_logger

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -966,8 +966,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
                 fee = self.out_fee
         else:
             raise CalculationError(
-                "_calc_withdraw_one_coin doesn't support more than \
-            3 coins"
+                "_calc_withdraw_one_coin doesn't support more than 3 coins"
             )
 
         # Charge fee on D, not on y, e.g. reducing invariant LESS than charging user

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -620,13 +620,15 @@ def test_calc_withdraw_one_coin(vyper_cryptopool, amount, i):
     """Test `calc_withdraw_one_coin` against vyper implementation."""
     assume(amount < vyper_cryptopool.totalSupply())
 
+    n_coins = 2
+
     pool = initialize_pool(vyper_cryptopool)
 
     expected_dy = vyper_cryptopool.calc_withdraw_one_coin(amount, i)
     dy = pool.calc_withdraw_one_coin(amount, i)
     assert dy == expected_dy
 
-    expected_balances = [vyper_cryptopool.balances(i) for i in range(2)]
+    expected_balances = [vyper_cryptopool.balances(i) for i in range(n_coins)]
     assert pool.balances == expected_balances
 
 

--- a/test/unit/test_cryptopool.py
+++ b/test/unit/test_cryptopool.py
@@ -14,6 +14,7 @@ from curvesim.pool.cryptoswap.calcs.factory_2_coin import (
     _sqrt_int,
     geometric_mean,
 )
+from curvesim.exceptions import CalculationError
 
 
 def initialize_pool(vyper_cryptopool):
@@ -387,6 +388,10 @@ def test_tweak_price(
     old_oracle = pool._price_oracle
 
     # pylint: disable=protected-access
+    try:
+        pool._tweak_price(A, gamma, xp, 1, 0, 0)
+    except Exception as err:
+        assert isinstance(err, CalculationError)
     pool._tweak_price(A, gamma, xp, 1, last_price, 0)
     vyper_cryptopool.eval(f"self.tweak_price({A_gamma}, {xp}, {last_price}, 0)")
 
@@ -435,7 +440,7 @@ def test_tweak_price(
     xp[0] = xp[0] + pool.allowed_extra_profit // 10
 
     # omitting price will calculate the spot price in `tweak_price`
-    pool._tweak_price(A, gamma, xp, 1, 0, 0)
+    pool._tweak_price(A, gamma, xp, 1, None, 0)
     vyper_cryptopool.eval(f"self.tweak_price({A_gamma}, {xp}, 0, 0)")
 
     assert pool.price_scale == [vyper_cryptopool.price_scale()]
@@ -454,7 +459,7 @@ def test_tweak_price(
     xp[0] = xp[0] * 115 // 100
 
     # omitting price will calculate the spot price in `tweak_price`
-    pool._tweak_price(A, gamma, xp, 1, 0, 0)
+    pool._tweak_price(A, gamma, xp, 1, None, 0)
     vyper_cryptopool.eval(f"self.tweak_price({A_gamma}, {xp}, 0, 0)")
 
     assert pool.price_scale == [vyper_cryptopool.price_scale()]

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -144,7 +144,7 @@ def update_cached_values(vyper_tricrypto, tricrypto_math):
 
 D_UNIT = 10**18
 positive_balance = st.integers(min_value=10**5 * D_UNIT, max_value=10**11 * D_UNIT)
-lp_tokens = st.integers(min_value=1 * D_UNIT, max_value=4 * 10**4 * D_UNIT)
+lp_tokens = st.integers(min_value=1 * D_UNIT, max_value=2 * 10**4 * D_UNIT)
 amplification_coefficient = st.integers(min_value=MIN_A, max_value=MAX_A)
 gamma_coefficient = st.integers(min_value=MIN_GAMMA, max_value=MAX_GAMMA)
 price = st.integers(min_value=10**12, max_value=10**25)


### PR DESCRIPTION
### Description

Closes #217.

- Enabled 3-coin `Curvecryptopool._calc_withdraw_one_coin`. Its `p` return value (now of type `Optional[int]`) will always be `None` since the vyper method doesn't return `p`.
- Changed `Curvecryptopool._tweak_price`'s `p_i` param to be `Optional[int]`. If `p_i` is None, the spot price is used as the last price. A non-zero `p_i` value will replace `last_prices[i]`, and a 0 will imply that something went wrong in the calculation pipeline, leading to a `CalculationError`.


### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/71eL6dRTF-j1jAVTTnjd6qqnveAV9XeJFXy-EGpSy_E/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9zdGF0/aWMuYm9yZWRwYW5k/YS5jb20vYmxvZy93/cC1jb250ZW50L3Vw/bG9hZHMvMjAxNi8w/NC9jdXRlLWJhYnkt/YmVhdmVycy0zLTU3/MDUwZTdjN2Y4ZmZf/XzYwNS5qcGc)
