### PR TITLE
Stableswap admin fee

### DIFF
--- a/curvesim/pool/stableswap/metapool.py
+++ b/curvesim/pool/stableswap/metapool.py
@@ -45,7 +45,7 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
         tokens=None,
         fee=4 * 10**6,
         fee_mul=None,
-        admin_fee=0 * 10**9,
+        admin_fee=5 * 10**9,
         virtual_price=None,
     ):
         """
@@ -73,9 +73,6 @@ class CurveMetaPool(Pool):  # pylint: disable=too-many-instance-attributes
             amount of D invariant per LP token; can be used when
             missing `tokens` value.
         """
-        # FIXME: set admin_fee default back to 5 * 10**9
-        # once sim code is updated.  Right now we use 0
-        # to pass the CI tests.
         self.A = A
         self.n = n
 

--- a/curvesim/pool/stableswap/pool.py
+++ b/curvesim/pool/stableswap/pool.py
@@ -42,7 +42,7 @@ class CurvePool(Pool):  # pylint: disable=too-many-instance-attributes
         tokens=None,
         fee=4 * 10**6,
         fee_mul=None,
-        admin_fee=0 * 10**9,
+        admin_fee=5 * 10**9,
         virtual_price=None,
     ):
         """
@@ -68,9 +68,6 @@ class CurvePool(Pool):  # pylint: disable=too-many-instance-attributes
             amount of D invariant per LP token; can be used when
             missing `tokens` value.
         """
-        # FIXME: set admin_fee default back to 5 * 10**9
-        # once sim code is updated.  Right now we use 0
-        # to pass the CI tests.
         rates = rates or [10**18] * n
 
         self.A = A

--- a/curvesim/pool_data/metadata/stableswap.py
+++ b/curvesim/pool_data/metadata/stableswap.py
@@ -15,6 +15,7 @@ class StableswapMetaData(PoolMetaDataBase):
                 "n": len(data["coins"]["names"]),
                 "fee": data["params"]["fee"],
                 "fee_mul": data["params"]["fee_mul"],
+                "admin_fee": data["params"]["admin_fee"],
                 "virtual_price": data["reserves"]["virtual_price"],
             }
 

--- a/test/unit/test_pool_metadata.py
+++ b/test/unit/test_pool_metadata.py
@@ -16,7 +16,7 @@ POOL_TEST_METADATA_JSON = """
     "symbol": "3Crv",
     "version": 1,
     "pool_type": "REGISTRY_V1",
-    "params": {"A": 2000, "fee": 1000000, "fee_mul": null},
+    "params": {"A": 2000, "fee": 1000000, "fee_mul": null, "admin_fee": 5000000000},
     "coins": {
         "names": ["DAI", "USDC", "USDT"],
         "addresses": [
@@ -53,7 +53,7 @@ METAPOOL_TEST_METADATA_JSON = """
     "version": 1,
     "pool_type": "STABLE_FACTORY",
     "params": {
-        "A": 1500, "fee": 4000000, "fee_mul": null},
+        "A": 1500, "fee": 4000000, "fee_mul": null, "admin_fee": 5000000000},
         "coins": {
             "names": ["GUSD", "crvFRAX"],
             "addresses": [
@@ -232,6 +232,7 @@ def test_pool():
         "n": 3,
         "fee": 1000000,
         "fee_mul": None,
+        "admin_fee": 5000000000,
         "virtual_price": 1025499623208090719,
     }
     assert metadata.init_kwargs(normalize=False) == {
@@ -244,6 +245,7 @@ def test_pool():
         "n": 3,
         "fee": 1000000,
         "fee_mul": None,
+        "admin_fee": 5000000000,
         "virtual_price": 1025499623208090719,
         "rates": [
             1000000000000000000,
@@ -282,6 +284,7 @@ def test_metapool():
         "n": 2,
         "fee": 4000000,
         "fee_mul": None,
+        "admin_fee": 5000000000,
         "virtual_price": 1002128768748324821,
     }
 
@@ -294,6 +297,7 @@ def test_metapool():
         "n": 2,
         "fee": 4000000,
         "fee_mul": None,
+        "admin_fee": 5000000000,
         "virtual_price": 1002128768748324821,
         "rate_multiplier": 10000000000000000000000000000000000,
     }


### PR DESCRIPTION
### Description

Cleaned up some tech debt: admin fees were disabled for stableswap sims and the stableswap pools had zero default value.  The stableswap metadata now has the admin fee value and the pools have default set to 50% (50**9).

Cryptopools already have this configured although we don't claim admin fees in sims currently.

End-to-end test data needs to be regenerated to pass.

Closes #171.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://121clicks.com/wp-content/uploads/2021/10/cutest_animals_aww_reddit_group_07.jpg)
