### PR TITLE
Mutation bugs in `metrics.state_log.pool_state`

### DIFF
--- a/changelog.d/20231011_132850_philiplu97_pool_state.rst
+++ b/changelog.d/20231011_132850_philiplu97_pool_state.rst
@@ -1,0 +1,4 @@
+Changed
+-------
+
+- Used copy() in metrics.state_log.pool_state when referencing certain pool objects to avoid mutation bugs. 

--- a/curvesim/metrics/state_log/pool_state.py
+++ b/curvesim/metrics/state_log/pool_state.py
@@ -25,13 +25,13 @@ def get_cryptoswap_pool_state(pool):
     """Returns pool state for stableswap non-meta pools."""
     return {
         "D": pool.D,
-        "balances": pool.balances,
+        "balances": pool.balances.copy(),
         "tokens": pool.tokens,
-        "price_scale": pool.price_scale,
-        "_price_oracle": pool._price_oracle,  # pylint: disable=protected-access
+        "price_scale": pool.price_scale.copy(),
+        "_price_oracle": pool._price_oracle.copy(),  # pylint: disable=protected-access
         "xcp_profit": pool.xcp_profit,
         "xcp_profit_a": pool.xcp_profit_a,
-        "last_prices": pool.last_prices,
+        "last_prices": pool.last_prices.copy(),
         "last_prices_timestamp": pool.last_prices_timestamp,
         "not_adjusted": pool.not_adjusted,
     }
@@ -40,9 +40,9 @@ def get_cryptoswap_pool_state(pool):
 def get_stableswap_pool_state(pool):
     """Returns pool state for stableswap non-meta pools."""
     return {
-        "balances": pool.balances,
+        "balances": pool.balances.copy(),
         "tokens": pool.tokens,
-        "admin_balances": pool.admin_balances,
+        "admin_balances": pool.admin_balances.copy(),
     }
 
 


### PR DESCRIPTION
### Description

Fixes #273.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/YkbfwtaT4rhukb_pdEDgAw1Phyitnn83velRJOTJ-4Q/rs:fit:860:0:0/g:ce/aHR0cHM6Ly93d3cu/YnV6emFib3V0YmVl/cy5uZXQvaW1hZ2Vz/L0Vhc3Rlcm4tQ2Fy/cGVudGVyLUJlZS5q/cGc)
