### PR TITLE
Enable `_claim_admin_fees` for `CurveCryptoPool`

### DIFF
--- a/changelog.d/20231020_133429_philiplu97_tricrypto_claim_admin_fees.rst
+++ b/changelog.d/20231020_133429_philiplu97_tricrypto_claim_admin_fees.rst
@@ -1,0 +1,6 @@
+Changed
+-------
+
+- Enabled _claim_admin_fees for CurveCryptoPool. For maintainability, Tricrypto_ng's 
+implementation and usage patterns, which are in test/fixtures/curve/tricrypto_ng.vy 
+(Ctrl + F _claim_admin_fees), are used for both 2-coin and 3-coin Cryptoswap pools.

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -448,6 +448,14 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         self.virtual_price = virtual_price
 
     def _claim_admin_fees(self) -> None:
+        """
+        If the pool's profit has increased since the last fee claim, update profit,
+        pool value, and LP token supply to reflect the admin taking its share of the
+        fees by minting itself LP tokens. Otherwise, change nothing.
+
+        Tricrypto-NG and Cryptopool implement this functionality differently, so we
+        copy only Tricrypto-NG's way in this class for consistency.
+        """
         # no gulping logic needed for the python code
         A: int = self.A
         gamma: int = self.gamma
@@ -892,7 +900,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
 
         return dy
 
-    # pylint: disable-next=too-many-locals,too-many-arguments
+    # pylint: disable-next=too-many-locals,too-many-arguments, too-many-branches
     def _calc_withdraw_one_coin(
         self,
         A: int,
@@ -1054,7 +1062,8 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
             price_oracle: List[int] = self.internal_price_oracle()
             price: int = factory_2_coin.lp_price(virtual_price, price_oracle)
         elif self.n == 3:
-            # 3-coin vyper contract uses cached packed oracle prices instead of internal_price_oracle()
+            # 3-coin vyper contract uses cached packed oracle prices instead of
+            # internal_price_oracle()
             virtual_price = self.virtual_price
             price_oracle = self._price_oracle
             price = tricrypto_ng.lp_price(virtual_price, price_oracle)

--- a/test/fixtures/curve/tricrypto_ng.vy
+++ b/test/fixtures/curve/tricrypto_ng.vy
@@ -1211,11 +1211,16 @@ def _claim_admin_fees():
     #         `self.balances` yet: pool balances only account for incoming and
     #                  outgoing tokens excluding fees. Following 'gulps' fees:
 
-    for i in range(N_COINS):
-        if coins[i] == WETH20:
-            self.balances[i] = self.balance
-        else:
-            self.balances[i] = ERC20(coins[i]).balanceOf(self)
+    # curvesim: commented out this for loop to avoid overwriting balances to 
+    # empty(uint256[N_COINS]) since we aren't going to instantiate the ERC20 contracts
+    # for the coins in this pool, which would make testing cumbersome. Also, the Python 
+    # pool doesn't gulp.
+
+    # for i in range(N_COINS):
+    #     if coins[i] == WETH20:
+    #         self.balances[i] = self.balance
+    #     else:
+    #         self.balances[i] = ERC20(coins[i]).balanceOf(self)
 
     #            If the pool has made no profits, `xcp_profit == xcp_profit_a`
     #                         and the pool gulps nothing in the previous step.


### PR DESCRIPTION
### Description

Closes #231.

Enabled `_claim_admin_fees` for `CurveCryptoPool`. For maintainability, `tricrypto_ng.vy`'s implementation and usage patterns are used for both 2-coin and 3-coin Cryptoswap pools.  2-coin `CurveCryptoPool` and `cryptopool.vy` will diverge primarily by calling `_claim_admin_fees` with different timings; any calculations involved are largely the same. I expect that differences relative to the 2-coin vyper contract's behavior will average out to a negligible amount over the course of a sim pipeline. 

However, if `CurveCryptoPool` needs to simulate gulping, then the above solution **_will not_** be viable. One potential solution, as @chanhosuh says, would be to implement the following:

"Organize all these [`CurveCryptoPool`] functions by a sort of configuration based on pool version that specifies when [`_claim_admin_fees`] or [`_tweak_price`] should be called.  Then it's enforced by a function that checks what method it is in and what version the pool is."

Alternatively, adding statements like `if self.n == 2` or `if self.n == 3` to the functions that call `_claim_admin_fees` in either one of `tricrypto_ng.vy` or `cryptopool.vy` (`_tweak_price`, `add_liquidity`, `remove_liquidity`, and `remove_liquidity_one_coin`) plus `_claim_admin_fees` itself could work. Of course, these solutions are tricky and messy, but there's no going around that.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/iD9DyuSwQtQ4Wr21SM09br6DMgYDkPWQzQj9DVMv6gg/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9tZWRp/YS5nZXR0eWltYWdl/cy5jb20vaWQvMTE1/MzAxMjY5MS9waG90/by90d28tYmFieS13/aWxkLXJhYmJpdHMt/a2lzc2luZy5qcGc_/cz02MTJ4NjEyJnc9/MCZrPTIwJmM9T1ZS/OEhmQXVJc2hWME1q/WDdsNW5DTkxjV2lE/ZHpzSjhCZTFBZ1Fa/X2xZbz0)
