### PR TITLE
Tricrypto `add_liquidity` 

### DIFF
--- a/changelog.d/20231107_150206_philiplu97_tricrypto_add_liquidity.rst
+++ b/changelog.d/20231107_150206_philiplu97_tricrypto_add_liquidity.rst
@@ -1,0 +1,4 @@
+Changed
+-------
+
+- Updated CurveCryptoPool.add_liquidity to support deposits in 3-coin Cryptopools.

--- a/test/fixtures/curve/tricrypto_ng.vy
+++ b/test/fixtures/curve/tricrypto_ng.vy
@@ -582,33 +582,34 @@ def add_liquidity(
 
         if amounts[i] > 0:
 
-            if coins[i] == WETH20:
+            # curvesim: comment out unneeded coin transfer logic
+            # if coins[i] == WETH20:
 
-                self._transfer_in(
-                    coins[i],
-                    amounts[i],
-                    0,  # <-----------------------------------
-                    msg.value,  #                             | No callbacks
-                    empty(address),  # <----------------------| for
-                    empty(bytes32),  # <----------------------| add_liquidity.
-                    msg.sender,  #                            |
-                    empty(address),  # <-----------------------
-                    use_eth
-                )
+            #     self._transfer_in(
+            #         coins[i],
+            #         amounts[i],
+            #         0,  # <-----------------------------------
+            #         msg.value,  #                             | No callbacks
+            #         empty(address),  # <----------------------| for
+            #         empty(bytes32),  # <----------------------| add_liquidity.
+            #         msg.sender,  #                            |
+            #         empty(address),  # <-----------------------
+            #         use_eth
+            #     )
 
-            else:
+            # else:
 
-                self._transfer_in(
-                    coins[i],
-                    amounts[i],
-                    0,
-                    0,  # <----------------- mvalue = 0 if coin is not WETH20.
-                    empty(address),
-                    empty(bytes32),
-                    msg.sender,
-                    empty(address),
-                    False  # <-------- use_eth is False if coin is not WETH20.
-                )
+            #     self._transfer_in(
+            #         coins[i],
+            #         amounts[i],
+            #         0,
+            #         0,  # <----------------- mvalue = 0 if coin is not WETH20.
+            #         empty(address),
+            #         empty(bytes32),
+            #         msg.sender,
+            #         empty(address),
+            #         False  # <-------- use_eth is False if coin is not WETH20.
+            #     )
 
             amountsp[i] = xp[i] - xp_old[i]
 

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -585,6 +585,38 @@ def test_calc_withdraw_one_coin(vyper_tricrypto, amount, i):
     assert pool.balances == expected_balances
 
 
+@given(positive_balance, positive_balance, positive_balance)
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_add_liquidity(vyper_tricrypto, x0, x1, x2):
+    n_coins = 3
+    assume(0.02 < x0 / x1 < 50)
+    assume(0.02 < x0 / x2 < 50)
+    assume(0.02 < x1 / x2 < 50)
+    xp = [x0, x1, x2]
+
+    precisions = vyper_tricrypto.precisions()
+    price_scale = [vyper_tricrypto.price_scale(i) for i in range(n_coins - 1)]
+    amounts = get_real_balances(xp, precisions, price_scale)
+
+    pool = initialize_pool(vyper_tricrypto)
+
+    expected_lp_amount = vyper_tricrypto.add_liquidity(amounts, 0)
+    expected_balances = [vyper_tricrypto.balances(i) for i in range(n_coins)]
+    expected_lp_supply = vyper_tricrypto.totalSupply()
+    expected_D = vyper_tricrypto.D()
+
+    lp_amount = pool.add_liquidity(amounts)
+
+    assert lp_amount == expected_lp_amount
+    assert pool.balances == expected_balances
+    assert pool.tokens == expected_lp_supply
+    assert pool.D == expected_D
+
+
 def test_claim_admin_fees(vyper_tricrypto, tricrypto_math):
     """Test admin fee claim against vyper implementation."""
     update_cached_values(vyper_tricrypto, tricrypto_math)


### PR DESCRIPTION
### Description

Closes #215.

- Updates `CurveCryptoPool.add_liquidity` to support deposits in 3-coin Cryptopools.
- `test_add_liquidity` in `test_tricrypto.py` is borrowed directly from `test_cryptopool.py`.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/jddFqWapuSFWsu316aRUHWizSu42v4vIUp-O6-bNTZE/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9pLnBp/bmltZy5jb20vb3Jp/Z2luYWxzLzBjL2Y4/L2JmLzBjZjhiZmUy/MGQ5OTQ3YWMxMWVh/YTkwZDNkYzRmY2Y4/LmpwZw)
