### PR TITLE
Tricrypto `remove_liquidity_one_coin` and `remove_liquidity`

### DIFF
--- a/changelog.d/20231108_115447_philiplu97_tricrypto_remove_liquidity_one_coin.rst
+++ b/changelog.d/20231108_115447_philiplu97_tricrypto_remove_liquidity_one_coin.rst
@@ -1,0 +1,10 @@
+Changed
+-------
+
+- Made CurveCryptoPool.remove_liquidity work for 3-coin pools, and it now returns the
+amounts of each coin withdrawn.
+
+- Made CurveCryptoPool.remove_liquidity_one_coin work for 3-coin pools.
+
+
+

--- a/curvesim/pool/cryptoswap/pool.py
+++ b/curvesim/pool/cryptoswap/pool.py
@@ -824,7 +824,7 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         self,
         _amount: int,
         min_amounts=None,
-    ):
+    ) -> List[int]:
         """
         Remove liquidity (burn LP tokens) to receive back part (or all) of
         the deposited funds.
@@ -840,22 +840,37 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         ----
         "This withdrawal method is very safe, does no complex math"
         """
-        min_amounts = min_amounts or [0, 0]
+        n_coins: int = self.n
+        min_amounts = min_amounts or [0] * n_coins
+
+        amount: int = _amount
+        balances: List[int] = self.balances
+        d_balances: List[int] = [0] * n_coins
 
         self._claim_admin_fees()
 
         total_supply: int = self.tokens
-        self.tokens -= _amount
-        balances: List[int] = self.balances
-        amount: int = _amount - 1  # Make rounding errors favoring other LPs a tiny bit
+        assert amount <= total_supply  # dev: token amount more than supply
+        self.tokens -= amount
 
-        for i in range(self.n):
-            d_balance: int = balances[i] * amount // total_supply
-            assert d_balance >= min_amounts[i]
-            self.balances[i] = balances[i] - d_balance
+        if amount == total_supply:  # case 1: withdrawal empties the pool
+
+            for i in range(n_coins):
+                d_balances[i] = balances[i]
+                self.balances[i] = 0
+
+        else:  # case 2: partial withdrawal
+            amount -= 1  # Make rounding errors favor other LPs a tiny bit
+
+            for i in range(n_coins):
+                d_balances[i] = balances[i] * amount // total_supply
+                assert d_balances[i] >= min_amounts[i]
+                self.balances[i] = balances[i] - d_balances[i]
 
         D: int = self.D
         self.D = D - D * amount // total_supply
+
+        return d_balances
 
     def remove_liquidity_one_coin(
         self, token_amount: int, i: int, min_amount: int
@@ -878,18 +893,20 @@ class CurveCryptoPool(Pool):  # pylint: disable=too-many-instance-attributes
         int
             Amount of the `i`-th coin received.
         """
-        A = self.A
-        gamma = self.gamma
+        A: int = self.A
+        gamma: int = self.gamma
 
         dy: int = 0
         D: int = 0
         p: Optional[int] = None
-        xp = [0] * self.n
+        xp: List[int] = [0] * self.n
 
         self._claim_admin_fees()
 
+        calc_price: bool = self.n == 2
+
         dy, p, D, xp = self._calc_withdraw_one_coin(
-            A, gamma, token_amount, i, False, True
+            A, gamma, token_amount, i, False, calc_price
         )
         assert dy >= min_amount, "Slippage"
 

--- a/test/fixtures/curve/tricrypto_ng.vy
+++ b/test/fixtures/curve/tricrypto_ng.vy
@@ -730,9 +730,10 @@ def remove_liquidity(
     #                                                             D will be 0.
 
     # ---------------------------------- Transfers ---------------------------
-
-    for i in range(N_COINS):
-        self._transfer_out(coins[i], d_balances[i], use_eth, receiver)
+    
+    # curvesim: comment out unneeded coin transfer logic
+    # for i in range(N_COINS):
+    #     self._transfer_out(coins[i], d_balances[i], use_eth, receiver)
 
     log RemoveLiquidity(msg.sender, balances, total_supply - _amount)
 
@@ -786,7 +787,8 @@ def remove_liquidity_one_coin(
 
     self.balances[i] -= dy
     self.burnFrom(msg.sender, token_amount)
-    self._transfer_out(coins[i], dy, use_eth, receiver)
+    # curvesim: comment out unneeded coin transfer logic
+    # self._transfer_out(coins[i], dy, use_eth, receiver)
 
     packed_price_scale: uint256 = self.tweak_price(A_gamma, xp, D, 0)
     #        Safe to use D from _calc_withdraw_one_coin here ---^
@@ -1656,7 +1658,8 @@ def burnFrom(_to: address, _value: uint256) -> bool:
     @return bool Success.
     """
     self.totalSupply -= _value
-    self.balanceOf[_to] -= _value
+    # curvesim: comment out unused mapping
+    # self.balanceOf[_to] -= _value
 
     log Transfer(_to, empty(address), _value)
     return True

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -145,7 +145,7 @@ def update_cached_values(vyper_tricrypto, tricrypto_math):
 
 D_UNIT = 10**18
 positive_balance = st.integers(min_value=10**5 * D_UNIT, max_value=10**11 * D_UNIT)
-lp_tokens = st.integers(min_value=1 * D_UNIT, max_value=2 * 10**4 * D_UNIT)
+lp_tokens = st.integers(min_value=1 * D_UNIT, max_value=5 * 10**4 * D_UNIT)
 amplification_coefficient = st.integers(min_value=MIN_A, max_value=MAX_A)
 gamma_coefficient = st.integers(min_value=MIN_GAMMA, max_value=MAX_GAMMA)
 price = st.integers(min_value=10**12, max_value=10**25)
@@ -562,13 +562,16 @@ def test_price_oracle(vyper_tricrypto, price_oracle, last_prices, time_delta):
 
 @given(lp_tokens)
 @settings(
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.filter_too_much,
+    ],
     max_examples=5,
     deadline=None,
 )
 def test_remove_liquidity(vyper_tricrypto, amount):
     """Test `remove_liquidity` against vyper implementation."""
-    assume(amount < vyper_tricrypto.totalSupply())
+    assume(amount <= vyper_tricrypto.totalSupply())
 
     pool = initialize_pool(vyper_tricrypto)
 
@@ -586,37 +589,46 @@ def test_remove_liquidity(vyper_tricrypto, amount):
 
 @given(lp_tokens, st.integers(min_value=0, max_value=2))
 @settings(
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.filter_too_much,
+    ],
     max_examples=5,
     deadline=None,
 )
 def test_remove_liquidity_one_coin(vyper_tricrypto, amount, i):
     """Test `remove_liquidity_one_coin` against vyper implementation."""
-    assume(amount < vyper_tricrypto.totalSupply())
+    assume(amount <= vyper_tricrypto.totalSupply())
 
     pool = initialize_pool(vyper_tricrypto)
 
     vyper_tricrypto.remove_liquidity_one_coin(amount, i, 0)
-    expected_coin_balance = vyper_tricrypto.balances(i)
+    expected_balances = [vyper_tricrypto.balances(i) for i in range(3)]
     expected_lp_supply = vyper_tricrypto.totalSupply()
+    expected_D = vyper_tricrypto.D()
 
     pool.remove_liquidity_one_coin(amount, i, 0)
-    coin_balance = pool.balances[i]
+    balances = pool.balances
     lp_supply = pool.tokens
+    D = pool.D
 
-    assert coin_balance == expected_coin_balance
+    assert balances == expected_balances
     assert lp_supply == expected_lp_supply
+    assert D == expected_D
 
 
 @given(lp_tokens, st.integers(min_value=0, max_value=2))
 @settings(
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.filter_too_much,
+    ],
     max_examples=25,
     deadline=None,
 )
 def test_calc_withdraw_one_coin(vyper_tricrypto, amount, i):
     """Test `calc_withdraw_one_coin` against vyper implementation."""
-    assume(amount < vyper_tricrypto.totalSupply())
+    assume(amount <= vyper_tricrypto.totalSupply())
 
     n_coins = 3
 

--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -560,6 +560,54 @@ def test_price_oracle(vyper_tricrypto, price_oracle, last_prices, time_delta):
     ]
 
 
+@given(lp_tokens)
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_remove_liquidity(vyper_tricrypto, amount):
+    """Test `remove_liquidity` against vyper implementation."""
+    assume(amount < vyper_tricrypto.totalSupply())
+
+    pool = initialize_pool(vyper_tricrypto)
+
+    vyper_tricrypto.remove_liquidity(amount, [0, 0, 0])
+    expected_balances = [vyper_tricrypto.balances(i) for i in range(3)]
+    expected_lp_supply = vyper_tricrypto.totalSupply()
+    expected_D = vyper_tricrypto.D()
+
+    pool.remove_liquidity(amount)
+
+    assert pool.balances == expected_balances
+    assert pool.tokens == expected_lp_supply
+    assert pool.D == expected_D
+
+
+@given(lp_tokens, st.integers(min_value=0, max_value=2))
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    max_examples=5,
+    deadline=None,
+)
+def test_remove_liquidity_one_coin(vyper_tricrypto, amount, i):
+    """Test `remove_liquidity_one_coin` against vyper implementation."""
+    assume(amount < vyper_tricrypto.totalSupply())
+
+    pool = initialize_pool(vyper_tricrypto)
+
+    vyper_tricrypto.remove_liquidity_one_coin(amount, i, 0)
+    expected_coin_balance = vyper_tricrypto.balances(i)
+    expected_lp_supply = vyper_tricrypto.totalSupply()
+
+    pool.remove_liquidity_one_coin(amount, i, 0)
+    coin_balance = pool.balances[i]
+    lp_supply = pool.tokens
+
+    assert coin_balance == expected_coin_balance
+    assert lp_supply == expected_lp_supply
+
+
 @given(lp_tokens, st.integers(min_value=0, max_value=2))
 @settings(
     suppress_health_check=[HealthCheck.function_scoped_fixture],


### PR DESCRIPTION
### Description

Closes #218.

- Made `CurveCryptoPool`'s `remove_liquidity` and `remove_liquidity_one_coin` functions work for 3-coin pools.
- New tests `test_remove_liquidity` and `test_remove_liquidity_one_coin` in `test_tricrypto.py` are borrowed directly from `test_cryptopool.py`.

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/m8JcE8u8nNUZ8Q-WRivqApBts88NYUd8WRnmO0kwbGc/rs:fit:860:0:0/g:ce/aHR0cHM6Ly90NC5m/dGNkbi5uZXQvanBn/LzAwLzM0LzAyLzgz/LzM2MF9GXzM0MDI4/MzcyX096Ykd4VkdZ/b3NWd2ZQeUI1RmdN/NVVtbXh6TFVEQVlS/LmpwZw)
