### PR TITLE
Fix tricrypto one-coin withdrawal tests

### DIFF
--- a/test/unit/test_tricrypto.py
+++ b/test/unit/test_tricrypto.py
@@ -598,7 +598,7 @@ def test_remove_liquidity(vyper_tricrypto, amount):
 )
 def test_remove_liquidity_one_coin(vyper_tricrypto, amount, i):
     """Test `remove_liquidity_one_coin` against vyper implementation."""
-    assume(amount <= vyper_tricrypto.totalSupply())
+    assume(amount <= vyper_tricrypto.totalSupply() // 3)
 
     pool = initialize_pool(vyper_tricrypto)
 
@@ -628,9 +628,7 @@ def test_remove_liquidity_one_coin(vyper_tricrypto, amount, i):
 )
 def test_calc_withdraw_one_coin(vyper_tricrypto, amount, i):
     """Test `calc_withdraw_one_coin` against vyper implementation."""
-    assume(amount <= vyper_tricrypto.totalSupply())
-
-    n_coins = 3
+    assume(amount <= vyper_tricrypto.totalSupply() // 3)
 
     pool = initialize_pool(vyper_tricrypto)
 
@@ -641,7 +639,7 @@ def test_calc_withdraw_one_coin(vyper_tricrypto, amount, i):
     dy = pool.calc_withdraw_one_coin(amount, i)
     assert dy == expected_dy
 
-    expected_balances = [vyper_tricrypto.balances(i) for i in range(n_coins)]
+    expected_balances = [vyper_tricrypto.balances(i) for i in range(3)]
     assert pool.balances == expected_balances
 
 


### PR DESCRIPTION
### Description

Small fixes for `test_remove_liquidity_one_coin` and `test_calc_withdraw_one_coin` in `test_tricrypto.py`

### Hygiene checklist

- [ ] Changelog entry
- [ ] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [ ] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
