### PR TITLE
Add triage and refactor plan

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,7 @@ Contributor Guide
    :maxdepth: 2
 
    contributing
+   simulation_redesign
 
 
 Support

--- a/docs/simulation_redesign.rst
+++ b/docs/simulation_redesign.rst
@@ -141,6 +141,39 @@ Why this phase matters:
 * the broker becomes the single place to add delayed execution later
 * the public APIs can remain largely unchanged
 
+Illustrative code sketch:
+
+.. code-block:: python
+
+   pool, pool_metadata = get_pool_data(metadata_or_address, chain, env, pool_ts)
+   asset_data, time_sequence = get_asset_data(pool_metadata, time_sequence, src)
+   price_volume = PriceVolume(asset_data)
+
+   venue = CurveVenue("curve_pool", pool)
+   broker = Broker({"curve_pool": venue})
+   agent = VolumeLimitedArbAgent(
+       agent_id="arb_1",
+       venue_id="curve_pool",
+       vol_mult=vol_mult,
+   )
+
+   for sample in price_volume:
+       venue.prepare_for_time(sample.timestamp)
+       context = broker.make_context(
+           agent_id=agent.agent_id,
+           timestamp=sample.timestamp,
+           observation=sample,
+           venue_snapshots={"curve_pool": venue.snapshot()},
+       )
+       intents = agent.act(context)
+       broker.submit(sample.timestamp, intents)
+
+   results = adapt_broker_output_to_results(broker, metrics)
+
+This is intentionally close to today's volume-limited arbitrage path.  The
+important shift is only that agents emit intents and the broker owns execution
+and logging.
+
 
 Phase 2: Native ``Simulation`` Runtime
 --------------------------------------
@@ -180,6 +213,43 @@ Old entrypoints remain as wrappers:
 * ``autosim()`` builds a default ``Simulation``
 * ``simple.pipeline()`` builds a simple-arbitrage ``Simulation``
 * ``vol_limited_arb.pipeline()`` builds a volume-limited ``Simulation``
+
+Illustrative code sketch:
+
+.. code-block:: python
+
+   curve_3pool = CurvePoolVenue.from_address(
+       address="0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7",
+       chain="mainnet",
+       pool_ts=1707868800,
+       id="curve:3pool",
+   )
+
+   price_volume_feed = PriceVolumeFeed(
+       id="market:3pool",
+       venue_id="curve:3pool",
+       source="coingecko",
+   )
+
+   volume_limited_arb_agent = VolumeLimitedArbitrageAgent(
+       id="arb:1",
+       venue_id="curve:3pool",
+       feed_id="market:3pool",
+       volume_limit_model="pool_market_proportional",
+   )
+
+   sim = Simulation(
+       time_sequence=time_sequence,
+       venues=[curve_3pool],
+       feeds=[price_volume_feed],
+       agents=[volume_limited_arb_agent],
+       metrics=DEFAULT_METRICS,
+   )
+   results = sim.run()
+
+At this stage the transitional wiring is hidden inside the runtime.  The
+current pipeline entrypoints become convenience wrappers that construct these
+runtime objects and call ``Simulation.run()``.
 
 
 Phase 3: Order Lifecycle and Delayed Execution

--- a/docs/simulation_redesign.rst
+++ b/docs/simulation_redesign.rst
@@ -1,0 +1,284 @@
+Simulation Redesign
+===================
+
+This note sketches a phased redesign of the simulation runtime.  The intent is
+to preserve today's working arbitrage pipelines while moving toward a runtime
+that can support broader use-cases already envisioned in the docs, such as
+multiple venues, LP-token or basket trading, and non-pool venues like a
+collateralized debt position.
+
+
+Goals
+-----
+
+The redesign should:
+
+1. preserve today's public entrypoints during transition, especially
+   :func:`curvesim.sim.autosim` and the existing pipeline functions
+2. reduce implicit coupling between pool execution, strategy logic, and logging
+3. make execution flow explicit enough to support delayed execution and richer
+   venue behavior later
+4. support future use-cases beyond a single Curve pool versus a single
+   price-volume feed
+
+The redesign should not:
+
+1. require a big-bang rewrite
+2. require a config framework to be usable
+3. hide compatibility problems inside a large builder or container
+
+
+Current Constraints
+-------------------
+
+Today's runtime is shaped around:
+
+* a param sampler
+* a price sampler
+* a strategy
+* a trader that directly executes against a pool
+* a state log that records pool-centric state
+
+That works for today's simple and volume-limited arbitrage flows, but it
+creates tight coupling:
+
+* execution is embedded in the trader
+* logging is embedded in a pool-centric state log
+* strategies assume immediate execution
+* feeds are effectively modeled as ``PriceVolume``
+
+This makes broader scenarios awkward:
+
+* multiple venues in one run
+* delayed execution or partial fills
+* limit orders or timelocked protocol actions
+* venues that are not naturally "pools"
+
+
+Target Runtime Model
+--------------------
+
+The proposed direction is a brokered runtime.
+
+Core runtime roles:
+
+* ``Agent`` decides what to do
+* ``Broker`` validates, routes, executes, and records
+* ``Venue`` is anything that can accept economic actions
+* ``MarketFeed`` provides observations to the runtime
+* ``Recorder`` turns broker and venue state into metric inputs and results
+
+The broker is the center of the execution model.  Agents do not execute
+directly against venues.  Instead, they submit intents or orders to the broker,
+which:
+
+* checks compatibility
+* routes to the right venue
+* records fills, rejections, or pending states
+* emits normalized execution and position events
+
+
+Minimal Runtime Contracts
+-------------------------
+
+The first useful runtime should standardize a small set of contracts rather than
+introducing many abstractions at once.
+
+Suggested minimum contracts:
+
+* ``OrderIntent``: what an agent wants to do
+* ``Order``: broker-owned lifecycle state
+* ``ExecutionUpdate``: venue response to a submitted order
+* ``PositionUpdate``: broker-owned record of a change in holdings or liabilities
+* ``Event``: normalized record for metrics, debugging, and auditability
+
+The main point is not the exact class names.  The point is to separate:
+
+* decision-making
+* execution
+* account or position effects
+* logging
+
+
+Phase 1: Broker Wrapper
+-----------------------
+
+The first baby step should look very similar to today's volume-limited
+arbitrage flow.
+
+The old pieces remain:
+
+* ``PriceVolume``
+* current pool simulation interfaces
+* existing metric classes
+* current pipeline entrypoints
+
+New pieces are introduced as thin adapters:
+
+* ``CurveVenue`` wraps a current sim pool
+* ``VolumeLimitedArbAgent`` replaces the direct trader execution path
+* ``Broker`` accepts intents and routes them to the venue
+* ``Recorder`` or an adapter layer converts broker output into today's metric
+  inputs
+
+At this stage, execution can still be immediate and synchronous.  The point is
+to prove the contracts without changing the public shape too much.
+
+Illustrative flow:
+
+1. current pipeline builds the pool and market data as it does today
+2. pool is wrapped as a ``CurveVenue``
+3. ``PriceVolume`` samples are exposed to the agent via a lightweight decision
+   context
+4. agent emits ``OrderIntent`` objects instead of directly trading
+5. broker executes those intents against the venue and records the result
+6. recorder adapts broker state into the current results path
+
+Why this phase matters:
+
+* execution becomes explicit
+* logging moves out of the trader
+* the broker becomes the single place to add delayed execution later
+* the public APIs can remain largely unchanged
+
+
+Phase 2: Native ``Simulation`` Runtime
+--------------------------------------
+
+Once the brokered contracts are proven, the next step is to make them native
+instead of adapter-based.
+
+The central runtime becomes a ``Simulation`` object responsible for:
+
+* advancing time
+* collecting observations from feeds
+* giving each agent a read-only decision context
+* routing intents through the broker
+* recording results and producing metrics
+
+The core user-facing shape becomes something like:
+
+.. code-block:: python
+
+   sim = Simulation(
+       time_sequence=time_sequence,
+       venues=[curve_3pool],
+       feeds=[price_volume_feed],
+       agents=[volume_limited_arb_agent],
+       metrics=DEFAULT_METRICS,
+   )
+   results = sim.run()
+
+This stage should remove the most fiddly transitional code:
+
+* no manual broker setup in user code
+* no manual decision-context assembly in user code
+* no manual adaptation from event log to results
+
+Old entrypoints remain as wrappers:
+
+* ``autosim()`` builds a default ``Simulation``
+* ``simple.pipeline()`` builds a simple-arbitrage ``Simulation``
+* ``vol_limited_arb.pipeline()`` builds a volume-limited ``Simulation``
+
+
+Phase 3: Order Lifecycle and Delayed Execution
+----------------------------------------------
+
+Once the broker is native, the runtime can start supporting richer venue
+behavior without another conceptual rewrite.
+
+Examples of capabilities that should become possible at this stage:
+
+* delayed execution
+* limit orders
+* partial fills
+* cancellation and expiry
+* protocol actions with cooldowns or timelocks
+
+This does not require changing the ``Simulation`` shape again.  It requires
+extending the broker and venue interaction so that venues can return
+``accepted`` or ``pending`` updates rather than always returning an immediate
+fill.
+
+That is why the broker is important: it creates a place for order lifecycle
+state to live outside both the agent and the venue.
+
+
+Phase 4: Multi-Venue and Non-Pool Use-Cases
+-------------------------------------------
+
+With the broker and native ``Simulation`` runtime in place, the framework can
+expand to the use-cases already described in :doc:`advanced`:
+
+* routing through multiple pools
+* trading between competing venues
+* trading LP tokens or baskets
+* non-pool venues such as a collateralized debt position
+
+At this point, the current ``SimPool`` naming may become too narrow.  The
+important thing is not to force an early rename, but to ensure the runtime
+contracts are general enough that a venue does not have to literally be a pool.
+
+
+Metrics and Results Migration
+-----------------------------
+
+The existing metric system is valuable and should be preserved if possible.
+
+In the early phases, broker output should be adapted into a structure that
+today's metrics can consume.  That avoids a large rewrite while the runtime
+contracts are still settling.
+
+Later, metrics can move toward consuming normalized broker events and venue
+snapshots directly.  This migration should be incremental and only happen after
+the brokered execution model is stable.
+
+
+Backward Compatibility
+----------------------
+
+Compatibility should be treated as a requirement, not a cleanup item.
+
+During the transition:
+
+* ``autosim()`` remains the main convenience API
+* current pipeline functions remain available
+* existing result objects should remain intact
+* any new runtime objects should initially sit behind current entrypoints
+
+This keeps the redesign from becoming a broad API break while the runtime model
+is still being proven.
+
+
+Open Questions
+--------------
+
+The following questions should be answered before large implementation work
+begins:
+
+1. What is the smallest useful ``OrderIntent`` / ``ExecutionUpdate`` model?
+2. What must every ``Venue`` implement?
+3. How should the broker represent positions or portfolios?
+4. What is the minimal decision context agents should receive?
+5. How should current metrics consume broker output during the transition?
+6. How much of today's ``Strategy`` / ``Trader`` split should survive?
+
+These questions are small enough to be answered directly in code and design
+notes, and concrete enough to keep the redesign honest.
+
+
+Recommended Implementation Order
+--------------------------------
+
+1. Introduce broker-side execution objects and a thin ``CurveVenue`` adapter.
+2. Refactor the current volume-limited arbitrage path to submit intents through
+   the broker instead of trading directly.
+3. Add an adapter from broker output to the current metric/result path.
+4. Introduce a native ``Simulation`` runtime that owns the event loop.
+5. Re-express the current pipeline entrypoints as wrappers over ``Simulation``.
+6. Extend the broker for delayed execution and richer venue behaviors only after
+   the immediate-execution case is stable.
+
+This ordering keeps each step small enough to review and keeps the current
+product path alive while the redesign proceeds.

--- a/docs/triage_plan.rst
+++ b/docs/triage_plan.rst
@@ -138,20 +138,39 @@ Objectives:
 
 - Continue the refactor without breaking current users.
 - Land architectural improvements in a sequence that preserves reviewability.
+- Use a broker-centered runtime model so execution, logging, and future
+  multi-venue behavior can be introduced incrementally.
+
+See also:
+
+- ``docs/simulation_redesign.rst`` for the current runtime design note and
+  phased execution model.
 
 Proposed slice order:
 
-1. Complete issue ``#287`` by wiring ``DataSource`` and ``FileDataSource`` into the
-   existing pipeline with compatibility defaults.
-2. Complete issue ``#288`` by making ``Trader`` and ``StateLog`` stateless.
-3. Introduce a ``ReferenceMarket`` adapter behind existing pipeline behavior.
-4. Extract a reusable simulation runner / orchestration layer from the current pipeline.
-5. Deprecate ``autosim`` only after the new path has parity, docs, and tests.
+1. Introduce broker-side execution objects and a thin venue adapter around the
+   current pool simulation path, keeping the current volume-limited arbitrage
+   pipeline largely intact.
+2. Complete issue ``#288`` by making ``Trader`` and ``StateLog`` stateless and
+   routing execution through the broker rather than directly through the trader.
+3. Add an adapter from broker output to the current metric and results path so
+   existing metrics remain usable during the transition.
+4. Introduce a native ``Simulation`` runtime that owns the event loop and
+   re-expresses current pipeline entrypoints as wrappers over that runtime.
+5. Continue broader abstractions such as multi-venue execution or richer market
+   models only after the brokered immediate-execution path is stable.
+6. Deprecate ``autosim`` only after the new path has parity, docs, and tests.
 
 Checklist:
 
+- [ ] Write down the minimal broker order, execution, and event contracts before
+  changing core pipeline code.
+- [ ] Introduce a thin venue adapter for the current pool execution path.
 - [ ] Finish ``DataSource`` integration without removing current public APIs.
 - [ ] Remove ``pool`` state from trader and state-log components.
+- [ ] Add a compatibility layer from broker output to today's metrics.
+- [ ] Introduce ``Simulation`` as the native runtime without removing current
+  pipeline entrypoints.
 - [ ] Keep public pipeline entrypoints backward-compatible during the migration.
 - [ ] Add tests for each slice before deprecating old behavior.
 - [ ] Document the migration path before changing the default entrypoint.

--- a/docs/triage_plan.rst
+++ b/docs/triage_plan.rst
@@ -1,0 +1,188 @@
+Triage and Refactor Plan
+========================
+
+This document captures a practical plan for working through the current
+Curvesim backlog without blocking on the full simulation redesign.
+
+Status
+------
+
+This plan is based on repository and GitHub state as of March 29, 2026.
+
+There are three distinct workstreams:
+
+1. Stabilize current user-facing breakages in data access and simulation entrypoints.
+2. Clean up the open PR queue so there is one canonical path for each change.
+3. Split the simulation redesign into mergeable slices that preserve current behavior.
+
+
+Guiding Principles
+------------------
+
+- Do not block urgent fixes on the full redesign epic.
+- Keep ``autosim`` working until there is a proven replacement path.
+- Prefer small, testable, mergeable changes over one large refactor PR.
+- Use integration smoke tests to protect all external data dependencies.
+- Close or supersede stale PRs once a canonical branch exists.
+
+
+Current Assessment
+------------------
+
+The highest-priority issues are external data and API breakages:
+
+- Issue ``#304``: subgraph URL does not exist
+- Issue ``#300``: hosted subgraph URLs are no longer available
+- Issue ``#174``: transition away from fragile subgraph usage
+- Issue ``#296``: ``matic`` bug in Coingecko path
+- Issue ``#290``: stale README and docs around data access
+- Issue ``#81``: missing live API integration tests
+
+The key open PRs need triage before implementation starts:
+
+- PR ``#303`` should be treated as the main candidate for the current data fix path.
+- PR ``#305`` appears to overlap heavily with ``#303`` and should likely be closed or folded in.
+- PR ``#298`` is an older, narrower version of the same subgraph migration theme.
+- PR ``#301`` is too large to merge whole and should be decomposed into smaller follow-on changes.
+
+The redesign epic is already partially represented in ``main``:
+
+- ``curvesim/templates/data_source.py`` has ``DataSource`` and ``FileDataSource`` scaffolding.
+- ``curvesim/templates/time_sequence.py`` has ``TimeSequence`` support.
+- ``curvesim/templates/sim_asset.py`` has ``SimAsset`` abstractions.
+
+However, the new abstractions are not fully wired through the pipeline:
+
+- ``curvesim/templates/trader.py`` still keeps state via ``self.pool``.
+- ``curvesim/metrics/state_log/log.py`` still keeps state via ``self.pool``.
+- ``curvesim/sim/__init__.py`` still exposes ``autosim`` as the primary entrypoint.
+- ``FileDataSource`` exists as a template, but the end-to-end integration described in
+  issue ``#287`` is not complete.
+
+
+Execution Plan
+--------------
+
+Phase 1: Stabilize current behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Objectives:
+
+- Restore working metadata, volume, and price fetches for supported pools.
+- Fix obvious low-risk bugs that block current flows.
+- Update the minimum user-facing documentation needed to reflect reality.
+
+Checklist:
+
+- [ ] Review PR ``#303`` against ``main`` and identify what can be reused directly.
+- [ ] Confirm whether PR ``#305`` is a duplicate or partial continuation of ``#303``.
+- [ ] Implement or extract a canonical fix for subgraph and Curve API endpoint breakages.
+- [ ] Fix issue ``#296`` if still present on ``main``.
+- [ ] Update docs and notebook references that still describe deprecated endpoints.
+- [ ] Close or supersede PRs ``#298`` and ``#305`` once the canonical fix path is chosen.
+
+Exit criteria:
+
+- ``curvesim.pool.get(...)`` works for at least one known mainnet pool.
+- ``autosim(...)`` works on a known stable pool path.
+- Docs no longer reference clearly obsolete endpoints.
+
+
+Phase 2: Add regression coverage around external integrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Objectives:
+
+- Catch future API and endpoint breakages quickly.
+- Keep tests small enough to run regularly.
+
+Checklist:
+
+- [ ] Add a smoke test for metadata fetch.
+- [ ] Add a smoke test for pool volume fetch.
+- [ ] Add a smoke test for ``autosim`` on a representative pool.
+- [ ] Decide whether tests should hit live services directly or use deterministic recorded fixtures.
+- [ ] Document how these tests should be run in CI and locally.
+
+Exit criteria:
+
+- A minimal integration suite exists for the current data path.
+- The suite fails cleanly when an endpoint changes or disappears.
+
+
+Phase 3: Clean and reorder the PR / issue queue
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Objectives:
+
+- Reduce backlog ambiguity.
+- Make the remaining work easy to assign and review.
+
+Checklist:
+
+- [ ] Pick one canonical issue for the "current data path is broken" cluster.
+- [ ] Mark overlapping issues and PRs as blocked, superseded, or closed.
+- [ ] Convert PR ``#301`` into a tracked stack of smaller implementation slices.
+- [ ] Move broad redesign notes into issue checklists rather than leaving them implicit in a large PR.
+
+Exit criteria:
+
+- Each active workstream has one clear owner artifact: issue, PR, or checklist item.
+- There is no ambiguity about whether ``#298``, ``#303``, and ``#305`` are all still active.
+
+
+Phase 4: Split the simulation redesign into mergeable slices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Objectives:
+
+- Continue the refactor without breaking current users.
+- Land architectural improvements in a sequence that preserves reviewability.
+
+Proposed slice order:
+
+1. Complete issue ``#287`` by wiring ``DataSource`` and ``FileDataSource`` into the
+   existing pipeline with compatibility defaults.
+2. Complete issue ``#288`` by making ``Trader`` and ``StateLog`` stateless.
+3. Introduce a ``ReferenceMarket`` adapter behind existing pipeline behavior.
+4. Extract a reusable simulation runner / orchestration layer from the current pipeline.
+5. Deprecate ``autosim`` only after the new path has parity, docs, and tests.
+
+Checklist:
+
+- [ ] Finish ``DataSource`` integration without removing current public APIs.
+- [ ] Remove ``pool`` state from trader and state-log components.
+- [ ] Keep public pipeline entrypoints backward-compatible during the migration.
+- [ ] Add tests for each slice before deprecating old behavior.
+- [ ] Document the migration path before changing the default entrypoint.
+
+Exit criteria:
+
+- Each slice can merge independently.
+- The redesign no longer depends on a single large PR.
+- ``autosim`` remains functional until explicitly deprecated.
+
+
+Deferred Work
+-------------
+
+The following should generally wait until Phases 1 through 3 are complete unless
+they directly support stabilization:
+
+- Issue ``#299``: StableSwap NG oracle support
+- Issue ``#297``: exponential smoothing
+- Issue ``#294``: price impact tool
+- Issue ``#292``: extend pool factory to cryptoswap
+- Issue ``#291``: Altair deprecation warning
+
+
+Recommended Next Actions
+------------------------
+
+1. Review PR ``#303`` first and decide whether it should be revived or replaced by a
+   fresh smaller PR.
+2. Triage PRs ``#298`` and ``#305`` relative to that decision.
+3. Fix the current data path on ``main`` before starting new feature work.
+4. Open explicit child tasks for issue ``#287`` and issue ``#288`` if they need to
+   be broken down further.
+5. Treat PR ``#301`` as a design source, not as the next merge target.


### PR DESCRIPTION
### Description

This PR adds a planning document for [backlog triage and staged cleanup](https://github.com/curveresearch/curvesim/blob/codex-triage-plan/docs/triage_plan.rst), and now also includes a concrete simulation redesign note.

The redesign note in [docs/simulation_redesign.rst](https://github.com/curveresearch/curvesim/blob/codex-triage-plan/docs/simulation_redesign.rst) lays out:

- the broker-centered runtime direction
- a first baby-step refactor that stays close to the current volume-limited arbitrage path
- the next-stage `Simulation` runtime
- later phases for delayed execution and broader multi-venue / non-pool use-cases
- compatibility and metric-migration constraints

The goal is to make the larger sim redesign more concrete and incremental, so the work can proceed in reviewable slices rather than as one large architecture PR.

### Hygiene checklist

- [ ] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)

### Cute Animal Picture

![cute hamster](https://images.unsplash.com/photo-1425082661705-1834bfd09dca?auto=format&fit=crop&w=800&q=80)
