### PR TITLE
Phase 1: restore data paths and autosim compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
         python3 -m test.simple_ci --generate
 
     - name: Upload results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-data
         path: test/data
@@ -86,7 +86,7 @@ jobs:
           rm -r curvesim
 
       - name: Download comparison results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-data
           path: test/data
@@ -133,7 +133,7 @@ jobs:
           pytest --cov -n auto --cov-report=
 
       - name: Download comparison results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-data
           path: test/data
@@ -185,7 +185,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
  
       - name: Store PR comment for posting
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
           # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         echo "Score: ${SCORE}"
 
     - name: Save previous pylint score
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pylint-score
         path: pylint_score.txt
@@ -69,7 +69,7 @@ jobs:
           make flake8
 
       - name: Get previous pylint score
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pylint-score
           path: ./pylint_score.txt

--- a/changelog.d/20260329_000000_phase1_data_path_fixes.rst
+++ b/changelog.d/20260329_000000_phase1_data_path_fixes.rst
@@ -1,0 +1,10 @@
+Changed
+-------
+- Updated Curve API usage to the current ``prices.curve.finance`` domain.
+- Switched primary pool snapshot retrieval to the Curve API-backed ``curve_prices`` path.
+
+Fixed
+-----
+- Fixed address-based pool metadata and ``autosim()`` failures caused by the deprecated hosted subgraph path.
+- Restored ``autosim()`` compatibility for the documented ``days`` and ``test`` arguments.
+- Fixed the CoinGecko ``matic`` chain alias mapping.

--- a/curvesim/network/coingecko.py
+++ b/curvesim/network/coingecko.py
@@ -17,7 +17,7 @@ PLATFORMS = {
     "xdai": "xdai",
     "fantom": "fantom",
     "avalanche": "avalanche",
-    "matic:": "polygon-pos",
+    "matic": "polygon-pos",
 }
 
 

--- a/curvesim/network/curve_prices.py
+++ b/curvesim/network/curve_prices.py
@@ -147,6 +147,7 @@ async def _pool_tvl_snapshots(
     return response["data"]
 
 
+# pylint: disable-next=too-many-locals
 async def pool_snapshot(
     address: str, chain: str = "ethereum", end_ts: Optional[int] = None
 ) -> Dict:

--- a/curvesim/network/curve_prices.py
+++ b/curvesim/network/curve_prices.py
@@ -2,19 +2,23 @@
 Network connector for Curve Prices API.
 """
 
-from typing import List
+from time import time
+from typing import Dict, List, Optional
 
 from eth_utils import to_checksum_address
 from pandas import DataFrame, to_datetime
 
-from curvesim.exceptions import ApiResultError, CurvesimValueError
+from curvesim.exceptions import ApiResultError
 
 from .http import HTTP
 from .utils import sync
 
-URL = "https://prices.curve.fi/v1/"
+URL = "https://prices.curve.finance/v1/"
 
-CHAIN_ALIASES = {"mainnet": "ethereum"}
+CHAIN_ALIASES = {
+    "mainnet": "ethereum",
+    "matic": "polygon",
+}
 
 
 async def _get_pool_pair_volume(
@@ -114,16 +118,221 @@ async def get_pool_pair_volume(
     return df
 
 
+async def _pool_metadata(address: str, chain: str) -> Dict:
+    chain = _chain_from_alias(chain)
+    address = to_checksum_address(address)
+    url = URL + f"pools/{chain}/{address}/metadata"
+    return await HTTP.get(url)
+
+
+async def _pool_snapshots(
+    address: str, chain: str, start_ts: int, end_ts: int
+) -> List[Dict]:
+    chain = _chain_from_alias(chain)
+    address = to_checksum_address(address)
+    url = URL + f"snapshots/{chain}/{address}"
+    params = {"start": start_ts, "end": end_ts}
+    response = await HTTP.get(url, params=params)
+    return response["data"]
+
+
+async def _pool_tvl_snapshots(
+    address: str, chain: str, start_ts: int, end_ts: int, unit: str = "day"
+) -> List[Dict]:
+    chain = _chain_from_alias(chain)
+    address = to_checksum_address(address)
+    url = URL + f"snapshots/{chain}/{address}/tvl"
+    params = {"start": start_ts, "end": end_ts, "unit": unit}
+    response = await HTTP.get(url, params=params)
+    return response["data"]
+
+
+async def pool_snapshot(
+    address: str, chain: str = "ethereum", end_ts: Optional[int] = None
+) -> Dict:
+    """
+    Pulls pool metadata and the latest snapshot from the current Curve API.
+
+    Parameters
+    ----------
+    address : str
+        Pool address.
+
+    chain : str, default="ethereum"
+        Chain name or alias.
+
+    end_ts : int, optional
+        Unix timestamp cutoff. The latest snapshot at or before this timestamp
+        will be used.
+
+    Returns
+    -------
+    dict
+        Pool metadata in the same general shape returned by the subgraph helper.
+    """
+    if end_ts is None:
+        end_ts = int(time())
+
+    # The Curve API serves recent snapshots, but not every chain/pool has dense
+    # historical coverage. A one-week window is enough to grab a recent point
+    # while still respecting the caller's cutoff.
+    start_ts = max(end_ts - 7 * 24 * 60 * 60, 0)
+    meta = await _pool_metadata(address, chain)
+    snapshots = await _pool_snapshots(address, chain, start_ts, end_ts)
+    tvl_snapshots = await _pool_tvl_snapshots(address, chain, start_ts, end_ts)
+
+    if not snapshots or not tvl_snapshots:
+        raise ApiResultError(
+            f"No pool snapshot returned for pool '{address}' on chain '{chain}'."
+        )
+
+    latest_snapshot = snapshots[0]
+    latest_tvl = tvl_snapshots[0]
+
+    sorted_coins = sorted(meta["coins"], key=lambda coin: coin["pool_index"])
+    balance_count = len(latest_tvl["balances"])
+
+    basepool = None
+    wrapper = None
+
+    if meta["metapool"]:
+        selected_coins = sorted_coins[:balance_count]
+        basepool = await pool_snapshot(meta["base_pool"], chain=chain, end_ts=end_ts)
+    elif len(sorted_coins) == 2 * balance_count:
+        wrapper_coins = sorted_coins[:balance_count]
+        selected_coins = sorted_coins[balance_count:]
+        wrapper = {
+            "names": [coin["symbol"] for coin in wrapper_coins],
+            "addresses": [
+                to_checksum_address(coin["address"]) for coin in wrapper_coins
+            ],
+            "decimals": [coin["decimals"] for coin in wrapper_coins],
+        }
+    else:
+        selected_coins = sorted_coins[:balance_count]
+
+    coins = {
+        "names": [coin["symbol"] for coin in selected_coins],
+        "addresses": [to_checksum_address(coin["address"]) for coin in selected_coins],
+        "decimals": [coin["decimals"] for coin in selected_coins],
+    }
+    if wrapper:
+        coins["wrapper"] = wrapper
+
+    normalized_reserves = []
+    unnormalized_reserves = []
+    for balance, coin in zip(latest_tvl["balances"], selected_coins):
+        unnormalized = int(balance * 10 ** coin["decimals"])
+        unnormalized_reserves.append(unnormalized)
+        normalized_reserves.append(unnormalized * 10 ** (18 - coin["decimals"]))
+
+    data = {
+        "name": meta["name"],
+        "address": to_checksum_address(address),
+        "chain": chain if chain not in CHAIN_ALIASES else chain,
+        "symbol": meta["name"],
+        "version": 2 if latest_snapshot["gamma"] is not None else 1,
+        "pool_type": _pool_type(meta, latest_snapshot),
+        "params": _pool_params(latest_snapshot, latest_tvl),
+        "coins": coins,
+        "reserves": {
+            "by_coin": normalized_reserves,
+            "unnormalized_by_coin": unnormalized_reserves,
+            "virtual_price": int(latest_snapshot["virtual_price"]),
+        },
+        "basepool": basepool,
+        "timestamp": int(latest_tvl["timestamp"]),
+    }
+
+    return data
+
+
+def _pool_type(meta: Dict, snapshot: Dict) -> str:
+    if meta["metapool"]:
+        return "METAPOOL_FACTORY" if meta["registry_type"] == "factory" else "METAPOOL"
+
+    if snapshot["gamma"] is not None:
+        pool_type = meta["pool_type"]
+        return {
+            "crypto": "REGISTRY_V2",
+            "factory_crypto": "CRYPTO_FACTORY",
+            "factory_tricrypto": "TRICRYPTO_FACTORY",
+            "twocryptong": "TWOCRYPTO_NG",
+        }.get(pool_type, pool_type.upper())
+
+    sorted_coins = sorted(meta["coins"], key=lambda coin: coin["pool_index"])
+    if len(sorted_coins) % 2 == 0:
+        first_half = [coin["symbol"] for coin in sorted_coins[: len(sorted_coins) // 2]]
+        second_half = [
+            coin["symbol"] for coin in sorted_coins[len(sorted_coins) // 2 :]
+        ]
+        if all(
+            wrapper.endswith(underlying)
+            for wrapper, underlying in zip(first_half, second_half)
+        ):
+            return "LENDING"
+
+    return "STABLE_FACTORY" if meta["registry_type"] == "factory" else "REGISTRY_V1"
+
+
+def _pool_params(snapshot: Dict, tvl_snapshot: Dict) -> Dict:
+    params = {
+        "A": int(snapshot["a"]),
+        "admin_fee": int(snapshot["admin_fee"]),
+    }
+
+    if snapshot["gamma"] is None:
+        offpeg = snapshot["offpeg_fee_multiplier"]
+        params.update(
+            {
+                "fee": int(snapshot["fee"]),
+                "fee_mul": int(offpeg) if offpeg is not None else None,
+            }
+        )
+        return params
+
+    derived_prices = _derived_crypto_prices(snapshot, tvl_snapshot)
+    params.update(
+        {
+            "gamma": int(snapshot["gamma"]),
+            "fee_gamma": int(snapshot["fee_gamma"]),
+            "mid_fee": int(snapshot["mid_fee"]),
+            "out_fee": int(snapshot["out_fee"]),
+            "allowed_extra_profit": int(snapshot["allowed_extra_profit"]),
+            "adjustment_step": int(snapshot["adjustment_step"]),
+            "ma_half_time": int(snapshot["ma_half_time"]),
+            "price_scale": derived_prices,
+            "price_oracle": derived_prices,
+            # The current API exposes live scale/oracle values but not the
+            # separate last_prices fields that older subgraph snapshots returned.
+            "last_prices": derived_prices,
+            "last_prices_timestamp": int(snapshot["timestamp"]),
+            "xcp_profit": int(snapshot["xcp_profit"]),
+            "xcp_profit_a": int(snapshot["xcp_profit_a"]),
+        }
+    )
+
+    return params
+
+
+def _derived_crypto_prices(snapshot: Dict, tvl_snapshot: Dict) -> List[int]:
+    if snapshot["price_scale"] is not None:
+        return [int(price) for price in snapshot["price_scale"]]
+
+    token_prices = tvl_snapshot["token_prices"]
+    if not token_prices:
+        raise ApiResultError("No token prices available for cryptoswap snapshot.")
+
+    base_price = token_prices[0]
+    return [int(price * 10**18 / base_price) for price in token_prices[1:]]
+
+
 def _chain_from_alias(chain):
     if chain in CHAIN_ALIASES:  # pylint: disable=consider-using-get
         chain = CHAIN_ALIASES[chain]
 
-    if chain != "ethereum":
-        raise CurvesimValueError(
-            "Curve Prices API currently only supports Ethereum chain."
-        )
-
     return chain
 
 
+pool_snapshot_sync = sync(pool_snapshot)
 get_pool_pair_volume_sync = sync(get_pool_pair_volume)

--- a/curvesim/network/curve_prices.py
+++ b/curvesim/network/curve_prices.py
@@ -3,7 +3,7 @@ Network connector for Curve Prices API.
 """
 
 from time import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from eth_utils import to_checksum_address
 from pandas import DataFrame, to_datetime
@@ -193,7 +193,7 @@ async def pool_snapshot(
     balance_count = len(latest_tvl["balances"])
 
     basepool = None
-    wrapper = None
+    wrapper: Optional[Dict[str, Any]] = None
 
     if meta["metapool"]:
         selected_coins = sorted_coins[:balance_count]
@@ -211,7 +211,7 @@ async def pool_snapshot(
     else:
         selected_coins = sorted_coins[:balance_count]
 
-    coins = {
+    coins: Dict[str, Any] = {
         "names": [coin["symbol"] for coin in selected_coins],
         "addresses": [to_checksum_address(coin["address"]) for coin in selected_coins],
         "decimals": [coin["decimals"] for coin in selected_coins],
@@ -275,8 +275,8 @@ def _pool_type(meta: Dict, snapshot: Dict) -> str:
     return "STABLE_FACTORY" if meta["registry_type"] == "factory" else "REGISTRY_V1"
 
 
-def _pool_params(snapshot: Dict, tvl_snapshot: Dict) -> Dict:
-    params = {
+def _pool_params(snapshot: Dict, tvl_snapshot: Dict) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
         "A": int(snapshot["a"]),
         "admin_fee": int(snapshot["admin_fee"]),
     }

--- a/curvesim/pool_data/queries/metadata.py
+++ b/curvesim/pool_data/queries/metadata.py
@@ -22,12 +22,12 @@ def from_address(address, chain, env="prod", end_ts=None):
     chain: str
         Chain name
     env: str
-        Environment name for subgraph: 'prod' or 'staging'
+        Environment name for the fallback subgraph: 'prod' or 'staging'
 
     Returns
     -------
     Pool snapshot dictionary in the format returned by
-    :func:`curvesim.network.subgraph.pool_snapshot`.
+    :func:`curvesim.network.curve_prices.pool_snapshot`.
     """
     loop = get_event_loop()
     try:
@@ -73,7 +73,7 @@ def get_metadata(
     end_ts: Optional[int] = None,
 ):
     """
-    Pulls pool state and metadata from daily snapshot.
+    Pulls pool state and metadata from the latest available pool snapshot.
 
     Parameters
     ----------
@@ -84,8 +84,8 @@ def get_metadata(
         Chain/layer2 identifier, e.g. “mainnet”, “arbitrum”, “optimism".
 
     end_ts : int, optional
-        Datetime cutoff, given as Unix timestamp, to pull last snapshot before.
-        The default value is current datetime, which will pull the most recent snapshot.
+        Datetime cutoff, given as Unix timestamp, to pull the latest snapshot
+        at or before. The default value is current datetime.
 
     Returns
     -------

--- a/curvesim/pool_data/queries/metadata.py
+++ b/curvesim/pool_data/queries/metadata.py
@@ -4,6 +4,9 @@ Functions to get pool metadata for Curve pools.
 from typing import Optional, Union
 
 from curvesim.constants import Chain, Env
+from curvesim.network.curve_prices import (
+    pool_snapshot_sync as curve_prices_pool_snapshot,
+)
 from curvesim.network.subgraph import pool_snapshot_sync, symbol_address_sync
 from curvesim.network.web3 import underlying_coin_info_sync
 from curvesim.pool_data.metadata import PoolMetaData
@@ -27,10 +30,17 @@ def from_address(address, chain, env="prod", end_ts=None):
     :func:`curvesim.network.subgraph.pool_snapshot`.
     """
     loop = get_event_loop()
-    data = pool_snapshot_sync(address, chain, env=env, end_ts=end_ts, event_loop=loop)
+    try:
+        data = curve_prices_pool_snapshot(
+            address, chain, end_ts=end_ts, event_loop=loop
+        )
+    except Exception:
+        data = pool_snapshot_sync(
+            address, chain, env=env, end_ts=end_ts, event_loop=loop
+        )
 
     # Get underlying token addresses
-    if data["pool_type"] == "LENDING":
+    if data["pool_type"] == "LENDING" and "wrapper" not in data["coins"]:
         u_addrs, u_decimals = underlying_coin_info_sync(
             data["coins"]["addresses"], event_loop=loop
         )

--- a/curvesim/sim/__init__.py
+++ b/curvesim/sim/__init__.py
@@ -11,9 +11,12 @@ Most users will want to use the `autosim` function, which supports
 The primary use-case is to determine optimal amplitude (A) and fee
 parameters given historical price and volume feeds.
 """
+from datetime import datetime, timedelta, timezone
+
 from curvesim.logging import get_logger
 from curvesim.pipelines.vol_limited_arb import pipeline as volume_limited_arbitrage
 from curvesim.pool_data import get_metadata
+from curvesim.templates import DateTimeSequence
 from curvesim.utils import get_pairs
 
 logger = get_logger(__name__)
@@ -139,6 +142,7 @@ def autosim(
     """
     assert any([pool, pool_metadata]), "Must input 'pool' or 'pool_metadata'"
 
+    kwargs = _apply_compat_defaults(kwargs)
     pool_metadata = pool_metadata or get_metadata(pool, chain, env)
     p_var, p_fixed, kwargs = _parse_arguments(pool_metadata, **kwargs)
 
@@ -150,6 +154,27 @@ def autosim(
     )
 
     return results
+
+
+def _apply_compat_defaults(kwargs):
+    kwargs = dict(kwargs)
+
+    if kwargs.pop("test", False):
+        kwargs["A"] = [100, 1000]
+        kwargs["fee"] = [3000000, 4000000]
+
+    days = kwargs.pop("days", None)
+    if days is not None and "time_sequence" not in kwargs:
+        kwargs["time_sequence"] = _make_time_sequence(days)
+
+    return kwargs
+
+
+def _make_time_sequence(days):
+    t_end = datetime.now(timezone.utc) - timedelta(days=1)
+    t_end = t_end.replace(hour=23, minute=0, second=0, microsecond=0)
+    t_start = t_end - timedelta(days=days) + timedelta(hours=1)
+    return DateTimeSequence.from_range(start=t_start, end=t_end, freq="1h")
 
 
 def _parse_arguments(pool_metadata, **kwargs):

--- a/curvesim/sim/__init__.py
+++ b/curvesim/sim/__init__.py
@@ -36,8 +36,8 @@ def autosim(
     The function fetches pool properties (e.g., current pool size) and 2
     months of price/volume data and runs multiple simulations in parallel.
 
-    Curve pools from any chain supported by the Convex Community Subgraphs
-    can be simulated directly by inputting the pool's address.
+    Curve pools from supported chains can be simulated directly by inputting
+    the pool's address.
 
     Parameters
     ----------
@@ -133,7 +133,8 @@ def autosim(
         Number of cores to use.
 
     env: str, default='prod'
-        Environment for the Curve subgraph, which pulls pool and volume snapshots.
+        Environment for the fallback subgraph path used when pool metadata
+        cannot be retrieved from the primary Curve API path.
 
     Returns
     -------

--- a/test/unit/test_curve_prices.py
+++ b/test/unit/test_curve_prices.py
@@ -1,0 +1,7 @@
+from curvesim.network.curve_prices import _chain_from_alias
+
+
+def test_curve_prices_chain_aliases():
+    assert _chain_from_alias("mainnet") == "ethereum"
+    assert _chain_from_alias("matic") == "polygon"
+    assert _chain_from_alias("arbitrum") == "arbitrum"

--- a/test/unit/test_phase1_compat.py
+++ b/test/unit/test_phase1_compat.py
@@ -1,0 +1,38 @@
+from curvesim.network.curve_prices import _chain_from_alias
+from curvesim.sim import _apply_compat_defaults
+from curvesim.templates import DateTimeSequence
+
+
+def test_curve_prices_chain_aliases():
+    assert _chain_from_alias("mainnet") == "ethereum"
+    assert _chain_from_alias("matic") == "polygon"
+    assert _chain_from_alias("arbitrum") == "arbitrum"
+
+
+def test_autosim_test_mode_restores_default_grid():
+    kwargs = _apply_compat_defaults({"test": True})
+
+    assert kwargs["A"] == [100, 1000]
+    assert kwargs["fee"] == [3000000, 4000000]
+
+
+def test_autosim_days_builds_time_sequence():
+    kwargs = _apply_compat_defaults({"days": 2})
+
+    time_sequence = kwargs["time_sequence"]
+    assert isinstance(time_sequence, DateTimeSequence)
+    assert len(time_sequence) == 48
+
+
+def test_autosim_days_preserves_explicit_time_sequence():
+    explicit_time_sequence = DateTimeSequence.from_range(
+        start="2024-01-01 00:00:00+00:00",
+        end="2024-01-01 02:00:00+00:00",
+        freq="1h",
+    )
+
+    kwargs = _apply_compat_defaults(
+        {"days": 2, "time_sequence": explicit_time_sequence}
+    )
+
+    assert kwargs["time_sequence"] is explicit_time_sequence

--- a/test/unit/test_sim.py
+++ b/test/unit/test_sim.py
@@ -1,12 +1,5 @@
-from curvesim.network.curve_prices import _chain_from_alias
 from curvesim.sim import _apply_compat_defaults
 from curvesim.templates import DateTimeSequence
-
-
-def test_curve_prices_chain_aliases():
-    assert _chain_from_alias("mainnet") == "ethereum"
-    assert _chain_from_alias("matic") == "polygon"
-    assert _chain_from_alias("arbitrum") == "arbitrum"
 
 
 def test_autosim_test_mode_restores_default_grid():


### PR DESCRIPTION
### Description

Fixes #304.
Fixes #300.
Fixes #296.

This PR restores the main data path on `main` by backporting the Curve API / `curve_prices.pool_snapshot_sync()` approach discussed by @allt0ld in #300, with the current `prices.curve.finance` domain and a few compatibility hardening changes for current API responses.

Concretely, it:
- switches address-based pool snapshot retrieval onto the current Curve API path
- updates the old `prices.curve.fi` host usage to `prices.curve.finance`
- preserves the metadata shape expected by the existing `main` pipeline
- keeps a subgraph fallback in place on `main` as a stabilization measure
- fixes the CoinGecko `matic` alias typo from #296
- restores `autosim()` compatibility for the documented `days` and `test` arguments

This is Phase 1 stabilization work, not the larger sim pipeline redesign. The goal is to restore a working baseline on `main` before the broader refactor lands.

Validation performed:
- `get_metadata()` works for 3Pool, an OUSD metapool, an Aave lending pool, and tricrypto2
- `get_pool_volume()` works for an Arbitrum pool
- `autosim('3Pool', days=2, test=True, ncpu=1)` completes successfully
- `env/bin/pytest -q test/unit/test_curve_prices.py test/unit/test_sim.py`

### Hygiene checklist

- [x] Changelog entry
- [x] Everything public has a Numpy-style docstring
      (modules, public functions, classes, and public methods)
- [x] Commit history is cleaned-up with minor changes squashed together
      and descriptive commit messages following [Tim Pope's style](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)

### Cute Animal Picture

![cute otter](https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?auto=format&fit=crop&w=800&q=80)
